### PR TITLE
feat: Cloudflare Worker CORS proxy for Zoho Invoice API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 VITE_ZOHO_CLIENT_ID=
-VITE_ZOHO_REDIRECT_URI=https://your-github-username.github.io/lions-portal-zoho-invoice-sync/
+VITE_ZOHO_REDIRECT_URI=https://your-github-username.github.io/lions-portal-zoho-invoice-sync
 VITE_ZOHO_REGION=com
+# Cloudflare Worker CORS proxy URL (no trailing slash).
+# Deploy worker/ with wrangler, then set this to your worker's URL.
+# Example: https://lions-portal-zoho-proxy.your-subdomain.workers.dev
+VITE_ZOHO_PROXY_URL=

--- a/src/components/OAuthCallback.jsx
+++ b/src/components/OAuthCallback.jsx
@@ -17,9 +17,7 @@ export default function OAuthCallback() {
     const params = new URLSearchParams(window.location.hash.replace(/^#/, ''))
     const accessToken = params.get('access_token')
     const expiresIn = params.get('expires_in')
-    const apiDomain = params.get('api_domain')
     const oauthError = params.get('error')
-    console.log('[OAuthCallback] hash params:', { apiDomain, expiresIn, hasToken: !!accessToken, allKeys: [...params.keys()] })
 
     if (oauthError) {
       setError(`Zoho returned an error: ${oauthError}`)
@@ -31,7 +29,7 @@ export default function OAuthCallback() {
       return
     }
 
-    handleCallback({ access_token: accessToken, expires_in: expiresIn, api_domain: apiDomain })
+    handleCallback({ access_token: accessToken, expires_in: expiresIn })
       .then(() => {
         // Strip the ?code= from the URL before navigating
         window.history.replaceState({}, '', window.location.pathname + '#/')

--- a/src/hooks/useCustomers.js
+++ b/src/hooks/useCustomers.js
@@ -3,11 +3,11 @@ import { fetchContacts, updateContact } from '../lib/zohoApi.js'
 import { useZohoAuth } from './useZohoAuth.js'
 
 export function useCustomers({ page = 1, perPage = 25 } = {}) {
-  const { accessToken, orgId, region, apiDomain } = useZohoAuth()
+  const { accessToken, orgId, region } = useZohoAuth()
 
   return useQuery({
     queryKey: ['contacts', orgId, page, perPage],
-    queryFn: () => fetchContacts(accessToken, orgId, region, apiDomain, { page, perPage }),
+    queryFn: () => fetchContacts(accessToken, orgId, region, { page, perPage }),
     enabled: !!(accessToken && orgId),
     placeholderData: keepPreviousData,
     staleTime: 60_000,
@@ -16,11 +16,11 @@ export function useCustomers({ page = 1, perPage = 25 } = {}) {
 
 export function useUpdateContact() {
   const queryClient = useQueryClient()
-  const { accessToken, orgId, region, apiDomain } = useZohoAuth()
+  const { accessToken, orgId, region } = useZohoAuth()
 
   return useMutation({
     mutationFn: ({ contactId, payload }) =>
-      updateContact(accessToken, orgId, region, apiDomain, contactId, payload),
+      updateContact(accessToken, orgId, region, contactId, payload),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['contacts'] })
     },

--- a/src/hooks/useZohoAuth.js
+++ b/src/hooks/useZohoAuth.js
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { BASE_ACCOUNTS, fetchOrganizations } from '../lib/zohoApi.js'
 
 const SESSION_KEY = 'zoho_session'
-const VERIFIER_KEY = 'zoho_pkce_verifier'
+const AUTH_STATE_KEY = 'zoho_auth_state'
 
 const SCOPES = [
   'ZohoInvoice.contacts.READ',
@@ -25,7 +25,7 @@ function saveSession(session) {
 
 function clearSession() {
   sessionStorage.removeItem(SESSION_KEY)
-  sessionStorage.removeItem(VERIFIER_KEY)
+  sessionStorage.removeItem(AUTH_STATE_KEY)
 }
 
 export function useZohoAuth() {
@@ -48,7 +48,7 @@ export function useZohoAuth() {
   }, [session])
 
   const login = useCallback((region = 'com') => {
-    sessionStorage.setItem(VERIFIER_KEY, JSON.stringify({ region }))
+    sessionStorage.setItem(AUTH_STATE_KEY, JSON.stringify({ region }))
 
     const clientId = import.meta.env.VITE_ZOHO_CLIENT_ID
     const redirectUri = import.meta.env.VITE_ZOHO_REDIRECT_URI
@@ -62,25 +62,24 @@ export function useZohoAuth() {
     window.location.href = authUrl.toString()
   }, [])
 
-  const handleCallback = useCallback(async ({ access_token, expires_in, api_domain }) => {
-    const raw = sessionStorage.getItem(VERIFIER_KEY)
+  const handleCallback = useCallback(async ({ access_token, expires_in }) => {
+    const raw = sessionStorage.getItem(AUTH_STATE_KEY)
     const { region } = raw ? JSON.parse(raw) : { region: 'com' }
 
-    const orgs = await fetchOrganizations(access_token, region, api_domain)
+    const orgs = await fetchOrganizations(access_token, region)
     if (!orgs.length) throw new Error('No Zoho Invoice organizations found for this account.')
 
     const newSession = {
       accessToken: access_token,
       expiresAt: Date.now() + (parseInt(expires_in) || 3600) * 1000,
       region,
-      apiDomain: api_domain,
       orgId: orgs[0].organization_id,
       orgs,
     }
 
     saveSession(newSession)
     setSession(newSession)
-    sessionStorage.removeItem(VERIFIER_KEY)
+    sessionStorage.removeItem(AUTH_STATE_KEY)
 
     return newSession
   }, [])
@@ -94,7 +93,6 @@ export function useZohoAuth() {
     isAuthenticated: !!session && Date.now() < (session?.expiresAt ?? 0),
     accessToken: session?.accessToken ?? null,
     region: session?.region ?? null,
-    apiDomain: session?.apiDomain ?? null,
     orgId: session?.orgId ?? null,
     orgs: session?.orgs ?? [],
     login,

--- a/src/lib/zohoApi.js
+++ b/src/lib/zohoApi.js
@@ -3,51 +3,30 @@
  *
  * Region suffixes: com | eu | in | com.au | jp
  * Australia uses "com.au" — not "au".
+ *
+ * Zoho Invoice does not support browser CORS. All /invoice/v3 calls are routed
+ * through a Cloudflare Worker proxy (VITE_ZOHO_PROXY_URL) that adds the
+ * required CORS headers.  The proxy path is /proxy/{region}/...
  */
 
 export const BASE_ACCOUNTS = (region) =>
   `https://accounts.zoho.${region}`
 
-// invoice.zoho.com does not support CORS for browser requests.
-// Use api_domain from the token response when available (Zoho's canonical regional API host).
-// Falls back to www.zohoapis.com for the given region.
-export const BASE_INVOICE = (region, apiDomain) =>
-  apiDomain ? `${apiDomain}/invoice/v3` : `https://www.zohoapis.${region}/invoice/v3`
+const PROXY_URL = import.meta.env.VITE_ZOHO_PROXY_URL
 
-/**
- * Exchange an authorization code for an access token.
- * Client-based applications have no client_secret.
- */
-export async function exchangeCodeForToken({ code, codeVerifier, clientId, redirectUri, region }) {
-  const url = `${BASE_ACCOUNTS(region)}/oauth/v2/token`
-  const body = new URLSearchParams({
-    grant_type: 'authorization_code',
-    client_id: clientId,
-    redirect_uri: redirectUri,
-    code,
-    code_verifier: codeVerifier,
-  })
-
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body,
-  })
-
-  if (!res.ok) {
-    const text = await res.text()
-    throw new Error(`Token exchange failed (${res.status}): ${text}`)
-  }
-
-  return res.json()
-}
+// Route through the CORS proxy when configured; fall back to direct for local
+// dev without a deployed worker.
+export const BASE_INVOICE = (region) =>
+  PROXY_URL
+    ? `${PROXY_URL}/proxy/${region}`
+    : `https://www.zohoapis.${region}/invoice/v3`
 
 /**
  * Fetch the list of organizations the token has access to.
  * Requires ZohoInvoice.settings.READ scope.
  */
-export async function fetchOrganizations(accessToken, region, apiDomain) {
-  const url = `${BASE_INVOICE(region, apiDomain)}/organizations`
+export async function fetchOrganizations(accessToken, region) {
+  const url = `${BASE_INVOICE(region)}/organizations`
   const res = await fetch(url, {
     headers: { Authorization: `Zoho-oauthtoken ${accessToken}` },
   })
@@ -64,8 +43,8 @@ export async function fetchOrganizations(accessToken, region, apiDomain) {
 /**
  * Fetch a paginated list of contacts (customers).
  */
-export async function fetchContacts(accessToken, orgId, region, apiDomain, { page = 1, perPage = 25 } = {}) {
-  const url = new URL(`${BASE_INVOICE(region, apiDomain)}/contacts`)
+export async function fetchContacts(accessToken, orgId, region, { page = 1, perPage = 25 } = {}) {
+  const url = new URL(`${BASE_INVOICE(region)}/contacts`)
   url.searchParams.set('organization_id', orgId)
   url.searchParams.set('page', page)
   url.searchParams.set('per_page', perPage)
@@ -88,8 +67,8 @@ export async function fetchContacts(accessToken, orgId, region, apiDomain, { pag
  * Update a single contact via PUT.
  * Zoho requires the full contact payload — partial updates are not supported.
  */
-export async function updateContact(accessToken, orgId, region, apiDomain, contactId, payload) {
-  const url = `${BASE_INVOICE(region, apiDomain)}/contacts/${contactId}?organization_id=${orgId}`
+export async function updateContact(accessToken, orgId, region, contactId, payload) {
+  const url = `${BASE_INVOICE(region)}/contacts/${contactId}?organization_id=${orgId}`
 
   const res = await fetch(url, {
     method: 'PUT',

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,0 +1,100 @@
+/**
+ * Cloudflare Worker — CORS proxy for Zoho Invoice API.
+ *
+ * Zoho Invoice (www.zohoapis.com/invoice/v3) does not emit CORS headers for
+ * browser requests, making direct fetch() calls impossible from a web app.
+ * This worker forwards requests to Zoho and adds the required CORS headers.
+ *
+ * Deployment:
+ *   wrangler deploy
+ *
+ * The ALLOWED_ORIGIN environment variable should be set to the GitHub Pages URL
+ * (or "*" for local dev — never use "*" in production).
+ */
+
+const ZOHO_BASE = 'https://www.zohoapis.'
+
+export default {
+  async fetch(request, env) {
+    const origin = request.headers.get('Origin') ?? ''
+
+    // Handle CORS preflight
+    if (request.method === 'OPTIONS') {
+      return corsResponse(null, 204, origin, env)
+    }
+
+    const url = new URL(request.url)
+
+    // Strip the leading /proxy/<region>/ prefix, e.g. /proxy/com/invoice/v3/...
+    // Path format: /proxy/{region}/{...rest}
+    const match = url.pathname.match(/^\/proxy\/([^/]+)\/(.*)$/)
+    if (!match) {
+      return corsResponse('Bad Request: path must be /proxy/{region}/...', 400, origin, env)
+    }
+
+    const [, region, rest] = match
+    const targetUrl = `${ZOHO_BASE}${region}/invoice/v3/${rest}${url.search}`
+
+    // Forward the request to Zoho
+    const upstream = new Request(targetUrl, {
+      method: request.method,
+      headers: forwardHeaders(request.headers),
+      body: ['GET', 'HEAD'].includes(request.method) ? undefined : request.body,
+      redirect: 'follow',
+    })
+
+    let zohoRes
+    try {
+      zohoRes = await fetch(upstream)
+    } catch (err) {
+      return corsResponse(`Upstream fetch failed: ${err.message}`, 502, origin, env)
+    }
+
+    const body = await zohoRes.arrayBuffer()
+    return corsResponse(body, zohoRes.status, origin, env, zohoRes.headers.get('Content-Type'))
+  },
+}
+
+/**
+ * Copy headers that Zoho needs, stripping hop-by-hop and Origin (would cause
+ * Zoho to see our worker origin, which is fine — but we omit Host so Cloudflare
+ * sets it correctly for the upstream request).
+ */
+function forwardHeaders(incoming) {
+  const out = new Headers()
+  for (const [key, value] of incoming.entries()) {
+    const lower = key.toLowerCase()
+    if (['host', 'origin', 'referer', 'cf-connecting-ip', 'cf-ray'].includes(lower)) continue
+    out.set(key, value)
+  }
+  return out
+}
+
+function allowedOrigin(origin, env) {
+  const allowed = env.ALLOWED_ORIGIN ?? '*'
+  if (allowed === '*') return '*'
+  // Support comma-separated list for multiple origins
+  return allowed.split(',').map((s) => s.trim()).includes(origin) ? origin : null
+}
+
+function corsResponse(body, status, origin, env, contentType) {
+  const ao = allowedOrigin(origin, env)
+  if (!ao) {
+    return new Response('Forbidden', { status: 403 })
+  }
+
+  const headers = new Headers({
+    'Access-Control-Allow-Origin': ao,
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+    'Access-Control-Max-Age': '86400',
+  })
+
+  if (contentType) headers.set('Content-Type', contentType)
+
+  if (body === null) {
+    return new Response(null, { status, headers })
+  }
+
+  return new Response(body, { status, headers })
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,7 @@
+name = "lions-portal-zoho-proxy"
+main = "worker/index.js"
+compatibility_date = "2024-01-01"
+
+# Set ALLOWED_ORIGIN via `wrangler secret put ALLOWED_ORIGIN` or in the
+# Cloudflare dashboard — do NOT commit secrets here.
+# Example: https://sffilamlions.github.io


### PR DESCRIPTION
## Summary

- Zoho Invoice API does not emit CORS headers for browser requests — confirmed by Zoho docs ("Server to server calls are only possible"). Direct `fetch()` from the SPA always fails with a CORS preflight error.
- Adds a **Cloudflare Worker** (`worker/index.js`) that proxies `/proxy/{region}/...` → `www.zohoapis.{region}/invoice/v3/...` and injects `Access-Control-Allow-*` headers. Origin is validated against the `ALLOWED_ORIGIN` worker secret.
- Routes all Zoho Invoice API calls through `VITE_ZOHO_PROXY_URL` when set; falls back to direct calls for local dev.
- Cleans up dead code from the PKCE → implicit flow migration: removes `exchangeCodeForToken`, drops the `apiDomain` parameter chain, removes debug `console.log`, renames `AUTH_STATE_KEY`.

## Deploy steps (before merging to main)

1. Install Wrangler: `npm i -g wrangler` (or `npx wrangler`)
2. Authenticate: `wrangler login`
3. Deploy worker: `wrangler deploy` (from repo root)
4. Set origin secret: `wrangler secret put ALLOWED_ORIGIN` → enter `https://sffilamlions.github.io`
5. Copy the worker URL (e.g. `https://lions-portal-zoho-proxy.<subdomain>.workers.dev`)
6. Add `VITE_ZOHO_PROXY_URL` GitHub Actions secret with that URL
7. Merge PR → Actions builds + deploys the SPA with proxy routing enabled

## Test plan

- [x] `wrangler deploy` succeeds, worker URL is live
- [ ] `npm run dev` with `VITE_ZOHO_PROXY_URL` set — login → customer table loads (no CORS errors in DevTools)
- [ ] `npm run dev` without `VITE_ZOHO_PROXY_URL` — falls back to direct calls (expected CORS failure, confirms fallback path)
- [ ] Worker rejects requests from unlisted origins with 403
- [ ] Edit a cell → Save All → contact updated in Zoho

🤖 Generated with [Claude Code](https://claude.com/claude-code)