### PR TITLE
feat: integrate Mantine UI framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "*.{json,yml,yaml,md,css}": "prettier --write"
   },
   "dependencies": {
+    "@mantine/core": "^8.3.18",
+    "@mantine/hooks": "^8.3.18",
+    "@mantine/modals": "^8.3.18",
     "@tanstack/react-query": "^5.62.0",
     "@tanstack/react-table": "^8.20.5",
     "react": "^18.3.1",

--- a/src/components/CustomerTable.jsx
+++ b/src/components/CustomerTable.jsx
@@ -4,6 +4,7 @@ import {
   getCoreRowModel,
   flexRender,
 } from '@tanstack/react-table'
+import { Alert, Badge, Button, Group, Stack, Table, Text } from '@mantine/core'
 import { useZohoAuth } from '../hooks/useZohoAuth.js'
 import { useCustomers, useUpdateContact } from '../hooks/useCustomers.js'
 import EditableCell from './EditableCell.jsx'
@@ -94,21 +95,9 @@ export default function CustomerTable() {
 
   const columns = useMemo(
     () => [
-      {
-        accessorKey: 'contact_name',
-        header: 'Name',
-        cell: EditableCell,
-      },
-      {
-        accessorKey: 'email',
-        header: 'Email',
-        cell: EditableCell,
-      },
-      {
-        accessorKey: 'phone',
-        header: 'Phone',
-        cell: EditableCell,
-      },
+      { accessorKey: 'contact_name', header: 'Name', cell: EditableCell },
+      { accessorKey: 'email', header: 'Email', cell: EditableCell },
+      { accessorKey: 'phone', header: 'Phone', cell: EditableCell },
       {
         accessorFn: (row) => row.billing_address?.address ?? '',
         id: 'address',
@@ -163,187 +152,94 @@ export default function CustomerTable() {
   const orgName = orgs.find((o) => o.organization_id === orgId)?.name ?? orgId
 
   return (
-    <div style={styles.page}>
-      <header style={styles.header}>
-        <div>
-          <h1 style={styles.title}>Customers</h1>
-          <span style={styles.org}>{orgName}</span>
-        </div>
-        <div style={styles.actions}>
+    <Stack p="lg" maw={1200} mx="auto" gap="md">
+      <Group justify="space-between" align="flex-start">
+        <Stack gap={4}>
+          <Text fw={700} size="xl">Customers</Text>
+          <Text size="sm" c="dimmed">{orgName}</Text>
+        </Stack>
+        <Group gap="xs" align="center">
           {dirtyCount > 0 && (
             <>
-              <span style={styles.dirtyBadge}>
+              <Badge color="yellow" variant="light">
                 {dirtyCount} unsaved change{dirtyCount !== 1 ? 's' : ''}
-              </span>
-              <button
-                style={styles.btnSecondary}
-                onClick={() => setDirtyMap({})}
-              >
+              </Badge>
+              <Button variant="default" size="sm" onClick={() => setDirtyMap({})}>
                 Discard
-              </button>
-              <button
-                style={styles.btnPrimary}
-                onClick={saveAll}
-                disabled={isFetching}
-              >
+              </Button>
+              <Button size="sm" color="orange" onClick={saveAll} disabled={isFetching}>
                 Save All
-              </button>
+              </Button>
             </>
           )}
-          <button style={styles.btnLogout} onClick={logout}>
+          <Button variant="subtle" color="gray" size="sm" onClick={logout}>
             Log out
-          </button>
-        </div>
-      </header>
+          </Button>
+        </Group>
+      </Group>
 
-      {isError && <p style={styles.error}>Error: {error?.message}</p>}
+      {isError && (
+        <Alert color="red" title="Error">
+          {error?.message}
+        </Alert>
+      )}
 
-      <div style={styles.tableWrapper}>
-        <table style={styles.table}>
-          <thead>
+      <div style={{ overflowX: 'auto' }}>
+        <Table striped highlightOnHover withTableBorder withColumnBorders fz="sm">
+          <Table.Thead>
             {table.getHeaderGroups().map((hg) => (
-              <tr key={hg.id}>
+              <Table.Tr key={hg.id}>
                 {hg.headers.map((header) => (
-                  <th key={header.id} style={styles.th}>
+                  <Table.Th key={header.id} style={{ whiteSpace: 'nowrap' }}>
                     {header.isPlaceholder
                       ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext()
-                        )}
-                  </th>
+                      : flexRender(header.column.columnDef.header, header.getContext())}
+                  </Table.Th>
                 ))}
-              </tr>
+              </Table.Tr>
             ))}
-          </thead>
-          <tbody>
+          </Table.Thead>
+          <Table.Tbody>
             {isLoading ? (
-              <tr>
-                <td colSpan={columns.length} style={styles.center}>
+              <Table.Tr>
+                <Table.Td colSpan={columns.length} ta="center" c="dimmed" py="xl">
                   Loading…
-                </td>
-              </tr>
+                </Table.Td>
+              </Table.Tr>
             ) : (
               table.getRowModel().rows.map((row) => (
-                <tr key={row.id} style={styles.tr}>
+                <Table.Tr key={row.id}>
                   {row.getVisibleCells().map((cell) => (
-                    <td key={cell.id} style={styles.td}>
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext()
-                      )}
-                    </td>
+                    <Table.Td key={cell.id} py={4} px={6}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </Table.Td>
                   ))}
-                </tr>
+                </Table.Tr>
               ))
             )}
-          </tbody>
-        </table>
+          </Table.Tbody>
+        </Table>
       </div>
 
-      <div style={styles.pagination}>
-        <button
-          style={styles.btnPage}
+      <Group gap="sm" align="center">
+        <Button
+          variant="default"
+          size="sm"
           onClick={() => setPage((p) => Math.max(1, p - 1))}
           disabled={page === 1 || isFetching}
         >
           ← Prev
-        </button>
-        <span style={styles.pageInfo}>Page {page}</span>
-        <button
-          style={styles.btnPage}
+        </Button>
+        <Text size="sm" c="dimmed">Page {page}</Text>
+        <Button
+          variant="default"
+          size="sm"
           onClick={() => setPage((p) => p + 1)}
           disabled={!pageContext.has_more_page || isFetching}
         >
           Next →
-        </button>
-      </div>
-    </div>
+        </Button>
+      </Group>
+    </Stack>
   )
-}
-
-const styles = {
-  page: {
-    fontFamily: 'system-ui, sans-serif',
-    padding: '1.5rem',
-    maxWidth: '1200px',
-    margin: '0 auto',
-  },
-  header: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
-    marginBottom: '1rem',
-  },
-  title: { margin: 0, fontSize: '1.5rem', color: '#111' },
-  org: { fontSize: '0.85rem', color: '#666' },
-  actions: { display: 'flex', gap: '0.5rem', alignItems: 'center' },
-  dirtyBadge: {
-    fontSize: '0.8rem',
-    background: '#fef3c7',
-    color: '#92400e',
-    padding: '3px 8px',
-    borderRadius: '9999px',
-    fontWeight: 600,
-  },
-  btnPrimary: {
-    padding: '0.45rem 1rem',
-    background: '#e0440e',
-    color: '#fff',
-    border: 'none',
-    borderRadius: '4px',
-    cursor: 'pointer',
-    fontWeight: 600,
-  },
-  btnSecondary: {
-    padding: '0.45rem 1rem',
-    background: '#e5e7eb',
-    color: '#374151',
-    border: 'none',
-    borderRadius: '4px',
-    cursor: 'pointer',
-  },
-  btnLogout: {
-    padding: '0.45rem 1rem',
-    background: 'transparent',
-    color: '#6b7280',
-    border: '1px solid #d1d5db',
-    borderRadius: '4px',
-    cursor: 'pointer',
-  },
-  btnPage: {
-    padding: '0.4rem 0.9rem',
-    background: '#f3f4f6',
-    border: '1px solid #d1d5db',
-    borderRadius: '4px',
-    cursor: 'pointer',
-  },
-  tableWrapper: { overflowX: 'auto' },
-  table: { width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' },
-  th: {
-    textAlign: 'left',
-    padding: '8px 10px',
-    background: '#f9fafb',
-    borderBottom: '2px solid #e5e7eb',
-    fontWeight: 600,
-    color: '#374151',
-    whiteSpace: 'nowrap',
-  },
-  tr: { borderBottom: '1px solid #f3f4f6' },
-  td: { padding: '4px 6px', verticalAlign: 'middle' },
-  center: { padding: '2rem', textAlign: 'center', color: '#888' },
-  pagination: {
-    display: 'flex',
-    gap: '0.75rem',
-    alignItems: 'center',
-    marginTop: '1rem',
-  },
-  pageInfo: { fontSize: '0.875rem', color: '#555' },
-  error: {
-    color: '#c00',
-    background: '#fff0f0',
-    padding: '0.75rem',
-    borderRadius: '4px',
-    marginBottom: '1rem',
-  },
 }

--- a/src/components/EditableCell.jsx
+++ b/src/components/EditableCell.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { TextInput } from '@mantine/core'
 
 export default function EditableCell({ getValue, row, column, table }) {
   const initialValue = getValue() ?? ''
@@ -14,28 +15,17 @@ export default function EditableCell({ getValue, row, column, table }) {
     }
   }
 
-  // Sync if the underlying data changes (e.g. after a save + re-fetch)
-  if (
-    initialValue !==
-    (table.options.meta?.getCommitted?.(contactId, columnId) ?? initialValue)
-  ) {
-    // no-op; keeping local value intentional until user blurs
-  }
-
   return (
-    <input
+    <TextInput
       value={value}
       onChange={(e) => setValue(e.target.value)}
       onBlur={handleBlur}
-      style={{
-        width: '100%',
-        boxSizing: 'border-box',
-        padding: '4px 6px',
-        border: isDirty ? '1.5px solid #f59e0b' : '1px solid #d1d5db',
-        borderRadius: '3px',
-        background: isDirty ? '#fefce8' : 'transparent',
-        fontSize: '0.875rem',
-        outline: 'none',
+      size="xs"
+      styles={{
+        input: {
+          borderColor: isDirty ? '#f59e0b' : undefined,
+          backgroundColor: isDirty ? '#fefce8' : undefined,
+        },
       }}
     />
   )

--- a/src/components/LoginPage.jsx
+++ b/src/components/LoginPage.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useZohoAuth } from '../hooks/useZohoAuth.js'
+import { Button, Center, Paper, Select, Stack, Text, Title } from '@mantine/core'
 
 const REGIONS = [
   { value: 'com', label: 'Global (US)' },
@@ -27,76 +28,28 @@ export default function LoginPage() {
   }
 
   return (
-    <div style={styles.container}>
-      <div style={styles.card}>
-        <h1 style={styles.title}>Zoho Invoice</h1>
-        <h2 style={styles.subtitle}>Customer Editor</h2>
+    <Center mih="100vh" bg="gray.1">
+      <Paper w={320} p="xl" radius="md" shadow="sm">
+        <Stack gap="sm">
+          <Title order={1} size="h3" c="#e0440e">Zoho Invoice</Title>
+          <Text size="md" c="dimmed" fw={400}>Customer Editor</Text>
 
-        <label style={styles.label} htmlFor="region">
-          Zoho region
-        </label>
-        <select
-          id="region"
-          value={region}
-          onChange={(e) => setRegion(e.target.value)}
-          style={styles.select}
-          disabled={loading}
-        >
-          {REGIONS.map((r) => (
-            <option key={r.value} value={r.value}>
-              {r.label}
-            </option>
-          ))}
-        </select>
+          <Select
+            label="Zoho region"
+            value={region}
+            onChange={setRegion}
+            disabled={loading}
+            data={REGIONS}
+            allowDeselect={false}
+          />
 
-        {error && <p style={styles.error}>{error}</p>}
+          {error && <Text size="sm" c="red">{error}</Text>}
 
-        <button style={styles.button} onClick={handleLogin} disabled={loading}>
-          {loading ? 'Redirecting…' : 'Connect to Zoho Invoice'}
-        </button>
-      </div>
-    </div>
+          <Button mt="xs" fullWidth color="#e0440e" onClick={handleLogin} disabled={loading}>
+            {loading ? 'Redirecting…' : 'Connect to Zoho Invoice'}
+          </Button>
+        </Stack>
+      </Paper>
+    </Center>
   )
-}
-
-const styles = {
-  container: {
-    minHeight: '100vh',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    background: '#f5f5f5',
-    fontFamily: 'system-ui, sans-serif',
-  },
-  card: {
-    background: '#fff',
-    padding: '2.5rem',
-    borderRadius: '8px',
-    boxShadow: '0 2px 12px rgba(0,0,0,.12)',
-    width: '320px',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '0.75rem',
-  },
-  title: { margin: 0, fontSize: '1.5rem', color: '#e0440e' },
-  subtitle: { margin: 0, fontSize: '1rem', color: '#555', fontWeight: 400 },
-  label: { fontSize: '0.875rem', color: '#333', fontWeight: 600 },
-  select: {
-    padding: '0.5rem',
-    borderRadius: '4px',
-    border: '1px solid #ccc',
-    fontSize: '0.9rem',
-  },
-  button: {
-    marginTop: '0.5rem',
-    padding: '0.75rem',
-    background: '#e0440e',
-    color: '#fff',
-    border: 'none',
-    borderRadius: '4px',
-    fontSize: '1rem',
-    cursor: 'pointer',
-    fontWeight: 600,
-  },
-  error: { color: '#c00', fontSize: '0.85rem', margin: 0 },
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,8 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { HashRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MantineProvider } from '@mantine/core'
+import '@mantine/core/styles.css'
 import App from './App.jsx'
 import './index.css'
 
@@ -16,10 +18,12 @@ const queryClient = new QueryClient({
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <HashRouter>
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    </HashRouter>
-  </React.StrictMode>
+    <MantineProvider>
+      <HashRouter>
+        <QueryClientProvider client={queryClient}>
+          <App />
+        </QueryClientProvider>
+      </HashRouter>
+    </MantineProvider>
+  </React.StrictMode>,
 )


### PR DESCRIPTION
## Summary

- Install `@mantine/core`, `@mantine/hooks`, `@mantine/modals`
- Wrap app in `<MantineProvider>` in `src/main.jsx`; import `@mantine/core/styles.css`
- Replace hand-rolled `<table>` in `CustomerTable` with Mantine `Table` / `Table.Thead` / `Table.Tbody` / `Table.Tr` / `Table.Th` / `Table.Td`
- Replace all inline `style={{}}` buttons with Mantine `Button` (variants: default, subtle, filled)
- Replace dirty-count `<span>` with Mantine `Badge`
- Replace layout `<div>` wrappers with Mantine `Group` and `Stack`
- Replace error `<p>` with Mantine `Alert`
- Replace `<input>` in `EditableCell` with Mantine `TextInput`; dirty highlight preserved via `styles.input`
- Replace `LoginPage` card layout with `Center` + `Paper`; native `<select>` with Mantine `Select`; `<h1>`/`<h2>` with `Title`/`Text`

## Test plan

- [ ] `npm run build` passes (verified: ✓ 807 modules, built in 1.72s)
- [ ] Login page renders with Mantine card + region Select
- [ ] CustomerTable renders with striped, bordered Mantine table
- [ ] Editing a cell still highlights it amber and shows the Badge
- [ ] Discard / Save All / Log out buttons work
- [ ] Pagination Prev/Next buttons work

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)