### PR TITLE
feat: add read-only view mode with edit/commit flow

### DIFF
--- a/src/components/CommitModal.jsx
+++ b/src/components/CommitModal.jsx
@@ -1,0 +1,131 @@
+import { useState } from 'react'
+import {
+  Alert,
+  Button,
+  Group,
+  Modal,
+  ScrollArea,
+  Stack,
+  Table,
+  Text,
+} from '@mantine/core'
+
+/**
+ * CommitModal — lists all pending changes and confirms save.
+ *
+ * Props:
+ *   opened       {boolean}
+ *   onClose      {() => void}       called when modal should close (cancel or done)
+ *   pendingChanges {Array<{
+ *     contactId: string,
+ *     contactName: string,
+ *     field: string,
+ *     original: string,
+ *     newValue: string,
+ *   }>}
+ *   onConfirm    {() => Promise<Map<string, Error|null>>}
+ *                resolves with a Map of contactId → Error (null means success)
+ */
+export default function CommitModal({
+  opened,
+  onClose,
+  pendingChanges,
+  onConfirm,
+}) {
+  const [saving, setSaving] = useState(false)
+  const [errors, setErrors] = useState({}) // { [contactId]: string }
+
+  async function handleConfirm() {
+    setSaving(true)
+    setErrors({})
+    try {
+      const resultMap = await onConfirm()
+      const newErrors = {}
+      for (const [contactId, err] of resultMap) {
+        if (err) newErrors[contactId] = err.message ?? String(err)
+      }
+      setErrors(newErrors)
+      if (Object.keys(newErrors).length === 0) {
+        onClose()
+      }
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function handleClose() {
+    if (saving) return
+    setErrors({})
+    onClose()
+  }
+
+  // Collect unique contact IDs that have errors
+  const contactIdsWithErrors = new Set(Object.keys(errors))
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={handleClose}
+      title="Confirm changes"
+      size="xl"
+      scrollAreaComponent={ScrollArea.Autosize}
+    >
+      <Stack gap="md">
+        <Text size="sm" c="dimmed">
+          Review the pending changes below. Click &ldquo;Confirm &amp;
+          Save&rdquo; to write them to Zoho.
+        </Text>
+
+        <Table withTableBorder withColumnBorders fz="sm">
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Contact</Table.Th>
+              <Table.Th>Field</Table.Th>
+              <Table.Th>Original</Table.Th>
+              <Table.Th>New value</Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {pendingChanges.map((change, i) => (
+              <Table.Tr
+                key={i}
+                style={
+                  contactIdsWithErrors.has(change.contactId)
+                    ? { backgroundColor: '#fff1f2' }
+                    : undefined
+                }
+              >
+                <Table.Td>{change.contactName}</Table.Td>
+                <Table.Td>{change.field}</Table.Td>
+                <Table.Td c="dimmed">{change.original}</Table.Td>
+                <Table.Td fw={500}>{change.newValue}</Table.Td>
+              </Table.Tr>
+            ))}
+          </Table.Tbody>
+        </Table>
+
+        {Object.entries(errors).map(([contactId, msg]) => {
+          const contact = pendingChanges.find((c) => c.contactId === contactId)
+          return (
+            <Alert
+              key={contactId}
+              color="red"
+              title={`Failed: ${contact?.contactName ?? contactId}`}
+            >
+              {msg}
+            </Alert>
+          )
+        })}
+
+        <Group justify="flex-end" gap="sm">
+          <Button variant="default" onClick={handleClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button color="orange" onClick={handleConfirm} loading={saving}>
+            Confirm &amp; Save
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  )
+}

--- a/src/components/CustomerTable.jsx
+++ b/src/components/CustomerTable.jsx
@@ -5,9 +5,11 @@ import {
   flexRender,
 } from '@tanstack/react-table'
 import { Alert, Badge, Button, Group, Stack, Table, Text } from '@mantine/core'
+import { useDisclosure } from '@mantine/hooks'
 import { useZohoAuth } from '../hooks/useZohoAuth.js'
 import { useCustomers, useUpdateContact } from '../hooks/useCustomers.js'
 import EditableCell from './EditableCell.jsx'
+import CommitModal from './CommitModal.jsx'
 
 const PER_PAGE = 25
 
@@ -53,8 +55,15 @@ export default function CustomerTable() {
   })
   const { mutateAsync: saveContact } = useUpdateContact()
 
+  // Edit mode toggle
+  const [isEditMode, setIsEditMode] = useState(false)
+
   // dirtyMap: { [contactId]: { [columnId]: newValue } }
   const [dirtyMap, setDirtyMap] = useState({})
+
+  // CommitModal open state
+  const [modalOpened, { open: openModal, close: closeModal }] =
+    useDisclosure(false)
 
   const markDirty = useCallback((contactId, columnId, value) => {
     setDirtyMap((prev) => ({
@@ -63,8 +72,27 @@ export default function CustomerTable() {
     }))
   }, [])
 
+  const clearDirty = useCallback((contactId, columnId) => {
+    setDirtyMap((prev) => {
+      const contactFields = { ...(prev[contactId] ?? {}) }
+      delete contactFields[columnId]
+      const next = { ...prev }
+      if (Object.keys(contactFields).length === 0) {
+        delete next[contactId]
+      } else {
+        next[contactId] = contactFields
+      }
+      return next
+    })
+  }, [])
+
   const isDirty = useCallback(
     (contactId, columnId) => dirtyMap[contactId]?.[columnId] !== undefined,
+    [dirtyMap]
+  )
+
+  const getDirtyValue = useCallback(
+    (contactId, columnId) => dirtyMap[contactId]?.[columnId],
     [dirtyMap]
   )
 
@@ -114,13 +142,47 @@ export default function CustomerTable() {
     columns,
     getCoreRowModel: getCoreRowModel(),
     getRowId: (row) => row.contact_id,
-    meta: { markDirty, isDirty },
+    meta: { isEditMode, markDirty, clearDirty, isDirty, getDirtyValue },
   })
 
-  async function saveAll() {
-    const entries = Object.entries(dirtyMap)
-    if (!entries.length) return
+  // Build the flat list of pending changes for CommitModal
+  const pendingChanges = useMemo(() => {
+    const changes = []
+    for (const [contactId, fields] of Object.entries(dirtyMap)) {
+      const contact = contacts.find((c) => c.contact_id === contactId)
+      if (!contact) continue
+      for (const [columnId, newValue] of Object.entries(fields)) {
+        // Resolve original value for this column
+        let original = ''
+        if (columnId === 'address') {
+          original = contact.billing_address?.address ?? ''
+        } else if (columnId.startsWith('cf_')) {
+          original =
+            contact.custom_fields?.find((f) => f.api_name === columnId)
+              ?.value ?? ''
+        } else {
+          original = contact[columnId] ?? ''
+        }
 
+        // Resolve human-readable field label from column definitions
+        const colDef = columns.find((c) => (c.accessorKey ?? c.id) === columnId)
+        const fieldLabel = colDef?.header ?? columnId
+
+        changes.push({
+          contactId,
+          contactName: contact.contact_name,
+          field: fieldLabel,
+          original,
+          newValue,
+        })
+      }
+    }
+    return changes
+  }, [dirtyMap, contacts, columns])
+
+  // Called by CommitModal — saves all dirty contacts and returns a Map of results
+  async function handleCommit() {
+    const entries = Object.entries(dirtyMap)
     const results = await Promise.allSettled(
       entries.map(([contactId, dirtyFields]) => {
         const original = contacts.find((c) => c.contact_id === contactId)
@@ -141,11 +203,33 @@ export default function CustomerTable() {
       return next
     })
 
-    const failed = results.filter((r) => r.status === 'rejected')
-    if (failed.length) {
-      alert(
-        `${failed.length} save(s) failed:\n${failed.map((f) => f.reason?.message).join('\n')}`
+    // Return a Map of contactId → Error|null for the modal to display
+    const resultMap = new Map()
+    entries.forEach(([contactId], i) => {
+      resultMap.set(
+        contactId,
+        results[i].status === 'rejected' ? results[i].reason : null
       )
+    })
+    return resultMap
+  }
+
+  function enterEditMode() {
+    setIsEditMode(true)
+  }
+
+  function cancelEditMode() {
+    setDirtyMap({})
+    setIsEditMode(false)
+  }
+
+  // After CommitModal closes following a successful save, exit edit mode
+  function handleModalClose() {
+    closeModal()
+    // If all changes were saved (dirtyMap is empty), exit edit mode
+    // If there were errors, stay in edit mode so the user can retry
+    if (Object.keys(dirtyMap).length === 0) {
+      setIsEditMode(false)
     }
   }
 
@@ -163,25 +247,28 @@ export default function CustomerTable() {
           </Text>
         </Stack>
         <Group gap="xs" align="center">
-          {dirtyCount > 0 && (
+          {!isEditMode && (
+            <Button size="sm" variant="light" onClick={enterEditMode}>
+              Edit
+            </Button>
+          )}
+          {isEditMode && (
             <>
-              <Badge color="yellow" variant="light">
-                {dirtyCount} unsaved change{dirtyCount !== 1 ? 's' : ''}
-              </Badge>
-              <Button
-                variant="default"
-                size="sm"
-                onClick={() => setDirtyMap({})}
-              >
-                Discard
+              {dirtyCount > 0 && (
+                <Badge color="yellow" variant="light">
+                  {dirtyCount} unsaved change{dirtyCount !== 1 ? 's' : ''}
+                </Badge>
+              )}
+              <Button variant="default" size="sm" onClick={cancelEditMode}>
+                Cancel
               </Button>
               <Button
                 size="sm"
                 color="orange"
-                onClick={saveAll}
-                disabled={isFetching}
+                onClick={openModal}
+                disabled={dirtyCount === 0 || isFetching}
               >
-                Save All
+                Commit
               </Button>
             </>
           )}
@@ -272,6 +359,13 @@ export default function CustomerTable() {
           Next →
         </Button>
       </Group>
+
+      <CommitModal
+        opened={modalOpened}
+        onClose={handleModalClose}
+        pendingChanges={pendingChanges}
+        onConfirm={handleCommit}
+      />
     </Stack>
   )
 }

--- a/src/components/EditableCell.jsx
+++ b/src/components/EditableCell.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { TextInput } from '@mantine/core'
+import { Stack, Text, TextInput } from '@mantine/core'
 
 export default function EditableCell({ getValue, row, column, table }) {
   const initialValue = getValue() ?? ''
@@ -7,26 +7,50 @@ export default function EditableCell({ getValue, row, column, table }) {
 
   const contactId = row.original.contact_id
   const columnId = column.id
-  const isDirty = table.options.meta?.isDirty(contactId, columnId) ?? false
+  const meta = table.options.meta ?? {}
+  const isEditMode = meta.isEditMode ?? false
+  const isDirty = meta.isDirty(contactId, columnId) ?? false
+  const dirtyValue = meta.getDirtyValue(contactId, columnId)
 
+  // The "original" text shown in the "was: ..." label is the server value
+  const originalValue = initialValue
+
+  // Displayed value: use dirtyMap value if dirty, otherwise the local state
+  // Local state tracks keystrokes; blur commits to dirtyMap
   function handleBlur() {
-    if (value !== initialValue) {
-      table.options.meta?.markDirty(contactId, columnId, value)
+    if (value !== originalValue) {
+      meta.markDirty(contactId, columnId, value)
+    } else if (isDirty && value === originalValue) {
+      // User reverted the value — remove from dirty map
+      meta.clearDirty(contactId, columnId)
     }
   }
 
+  if (!isEditMode) {
+    // View mode: plain text; show dirty value if present (shouldn't normally happen,
+    // but guards against stale state when toggling back without clearing)
+    return <Text size="sm">{isDirty ? dirtyValue : originalValue}</Text>
+  }
+
   return (
-    <TextInput
-      value={value}
-      onChange={(e) => setValue(e.target.value)}
-      onBlur={handleBlur}
-      size="xs"
-      styles={{
-        input: {
-          borderColor: isDirty ? '#f59e0b' : undefined,
-          backgroundColor: isDirty ? '#fefce8' : undefined,
-        },
-      }}
-    />
+    <Stack gap={2}>
+      <TextInput
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={handleBlur}
+        size="xs"
+        styles={{
+          input: {
+            borderColor: isDirty ? '#f59e0b' : undefined,
+            backgroundColor: isDirty ? '#fefce8' : undefined,
+          },
+        }}
+      />
+      {isDirty && (
+        <Text size="xs" c="dimmed" fs="italic">
+          was: {originalValue}
+        </Text>
+      )}
+    </Stack>
   )
 }


### PR DESCRIPTION
## Summary

- Adds a default read-only view mode where all cells render as plain text
- An **Edit** button in the toolbar switches to edit mode; **Cancel** discards dirty state and returns to view mode
- In edit mode, changed cells show a small `was: {original}` label beneath them
- A **Commit** button opens `CommitModal` which lists all pending changes (Contact | Field | Original | New) and fires `Promise.allSettled` on confirm; per-contact errors are shown inline and edit mode is only exited on full success

## Files changed

- `src/components/CustomerTable.jsx` — view/edit toggle, `clearDirty` helper, `CommitModal` integration, `pendingChanges` computed list, `handleModalClose` flow
- `src/components/EditableCell.jsx` — conditional render (plain `Text` vs `TextInput + 'was:' label`) driven by `meta.isEditMode`
- `src/components/CommitModal.jsx` — new Mantine `Modal` component listing pending changes with inline error alerts per contact

## Test plan

- [ ] Default state shows plain text in all cells
- [ ] Clicking Edit switches every cell to a text input
- [ ] Editing a cell and blurring shows the `was: ...` label and yellow highlight
- [ ] Cancel discards all changes and returns to view mode
- [ ] Commit button is disabled when no changes are pending
- [ ] Commit opens modal listing all changed rows with original/new values
- [ ] Confirm & Save fires saves; on full success, modal closes and view mode is restored
- [ ] If a save fails, the error is shown inline in the modal for that contact and edit mode is retained

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)