### PR TITLE
feat: split contact_name into first_name / last_name columns

### DIFF
--- a/src/components/CustomerTable.jsx
+++ b/src/components/CustomerTable.jsx
@@ -16,8 +16,13 @@ const PER_PAGE = 25
  * Zoho does not support partial updates, so we must send the full object.
  */
 function buildPayload(original, dirtyFields) {
+  const first = dirtyFields.first_name ?? original.first_name ?? ''
+  const last = dirtyFields.last_name ?? original.last_name ?? ''
+
   const payload = {
-    contact_name: original.contact_name,
+    contact_name: `${first} ${last}`.trim(),
+    first_name: first,
+    last_name: last,
     email: original.email ?? '',
     phone: original.phone ?? '',
     billing_address: {
@@ -27,7 +32,9 @@ function buildPayload(original, dirtyFields) {
   }
 
   for (const [field, value] of Object.entries(dirtyFields)) {
-    if (field === 'address') {
+    if (field === 'first_name' || field === 'last_name') {
+      // already handled above
+    } else if (field === 'address') {
       payload.billing_address.address = value
     } else if (field.startsWith('cf_')) {
       const idx = payload.custom_fields.findIndex((f) => f.api_name === field)
@@ -95,7 +102,8 @@ export default function CustomerTable() {
 
   const columns = useMemo(
     () => [
-      { accessorKey: 'contact_name', header: 'Name', cell: EditableCell },
+      { accessorKey: 'first_name', header: 'First Name', cell: EditableCell },
+      { accessorKey: 'last_name', header: 'Last Name', cell: EditableCell },
       { accessorKey: 'email', header: 'Email', cell: EditableCell },
       { accessorKey: 'phone', header: 'Phone', cell: EditableCell },
       {


### PR DESCRIPTION
## Summary

- Replaces the single **Name** column with separate **First Name** and **Last Name** columns
- `buildPayload` derives `contact_name` automatically as `` `${first} ${last}`.trim() `` so the Zoho PUT payload remains valid
- `dirtyMap` keys use `first_name` / `last_name` independently

## Test plan

- [ ] Table shows First Name and Last Name as separate editable columns
- [ ] Editing either column marks it dirty (yellow highlight)
- [ ] Saving updates both fields and the derived `contact_name` in Zoho
- [ ] Editing only one of the two names still produces a correct `contact_name`

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)