### PR TITLE
ci: deploy on every push to main, release only on schedule

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 name: Release & Deploy
 
 on:
+  push:
+    branches: [main]
   schedule:
     - cron: '0 2 * * *' # 2am UTC daily
   pull_request:
@@ -34,7 +36,7 @@ jobs:
         uses: reviewdog/action-actionlint@v1
 
   release:
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     needs: lint
     runs-on: ubuntu-latest
     outputs:
@@ -57,7 +59,7 @@ jobs:
 
   deploy:
     if: github.event_name != 'pull_request'
-    needs: release
+    needs: lint
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

- `deploy` now triggers on every push to `main` (decoupled from `release`, only needs `lint`)
- `release` (semantic-release/tagging) only runs on `schedule` or `workflow_dispatch`
- Reverts the behavior introduced in #29 where deploys were also gated behind the nightly schedule

## Trigger matrix

| Event | lint | deploy | release |
|-------|------|--------|---------|
| PR | ✓ | — | — |
| Push to `main` | ✓ | ✓ | — |
| Schedule (2am UTC) | ✓ | ✓ | ✓ |
| `workflow_dispatch` | ✓ | ✓ | ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)