### PR TITLE
fix: contact persons panel respects edit mode; expander shows count

### DIFF
--- a/src/components/ContactPersonsPanel.jsx
+++ b/src/components/ContactPersonsPanel.jsx
@@ -15,7 +15,10 @@ import {
 } from '../hooks/useContactPersons.js'
 import AddContactPersonRow from './AddContactPersonRow.jsx'
 
-function PersonCell({ value, isDirty, onChange }) {
+function PersonCell({ value, isDirty, onChange, isEditMode }) {
+  if (!isEditMode) {
+    return <Text size="xs">{value}</Text>
+  }
   return (
     <TextInput
       value={value}
@@ -31,7 +34,11 @@ function PersonCell({ value, isDirty, onChange }) {
   )
 }
 
-export default function ContactPersonsPanel({ contactId, contacts }) {
+export default function ContactPersonsPanel({
+  contactId,
+  contacts,
+  isEditMode,
+}) {
   const { data: persons, isLoading } = useContactPersons(contactId)
   const { mutateAsync: savePerson } = useUpdateContactPerson(contactId)
   const { mutateAsync: removePerson } = useDeleteContactPerson(contactId)
@@ -79,6 +86,10 @@ export default function ContactPersonsPanel({ contactId, contacts }) {
     setConfirmingDelete(null)
   }
 
+  // Number of columns: 5 text + Primary + Notify + Actions = 8
+  // In view mode the Actions column is hidden, so colSpan differs
+  const colCount = isEditMode ? 8 : 7
+
   return (
     <div style={{ padding: '0.5rem 1rem 0.75rem 2.5rem' }}>
       <Text size="xs" fw={600} c="dimmed" mb={6}>
@@ -91,13 +102,15 @@ export default function ContactPersonsPanel({ contactId, contacts }) {
       ) : !persons?.length && !showAdd ? (
         <Text size="xs" c="dimmed">
           No contact persons.{' '}
-          <Button
-            variant="subtle"
-            size="compact-xs"
-            onClick={() => setShowAdd(true)}
-          >
-            + Add
-          </Button>
+          {isEditMode && (
+            <Button
+              variant="subtle"
+              size="compact-xs"
+              onClick={() => setShowAdd(true)}
+            >
+              + Add
+            </Button>
+          )}
         </Text>
       ) : (
         <Table fz="xs" withTableBorder withColumnBorders>
@@ -110,7 +123,7 @@ export default function ContactPersonsPanel({ contactId, contacts }) {
               <Table.Th>Mobile</Table.Th>
               <Table.Th>Primary</Table.Th>
               <Table.Th>Notify</Table.Th>
-              <Table.Th />
+              {isEditMode && <Table.Th />}
             </Table.Tr>
           </Table.Thead>
           <Table.Tbody>
@@ -139,6 +152,7 @@ export default function ContactPersonsPanel({ contactId, contacts }) {
                       }
                       isDirty={dirty.first_name !== undefined}
                       onChange={(v) => markDirty(personId, 'first_name', v)}
+                      isEditMode={isEditMode}
                     />
                   </Table.Td>
                   <Table.Td>
@@ -150,6 +164,7 @@ export default function ContactPersonsPanel({ contactId, contacts }) {
                       }
                       isDirty={dirty.last_name !== undefined}
                       onChange={(v) => markDirty(personId, 'last_name', v)}
+                      isEditMode={isEditMode}
                     />
                   </Table.Td>
                   <Table.Td>
@@ -161,6 +176,7 @@ export default function ContactPersonsPanel({ contactId, contacts }) {
                       }
                       isDirty={dirty.email !== undefined}
                       onChange={(v) => markDirty(personId, 'email', v)}
+                      isEditMode={isEditMode}
                     />
                   </Table.Td>
                   <Table.Td>
@@ -172,6 +188,7 @@ export default function ContactPersonsPanel({ contactId, contacts }) {
                       }
                       isDirty={dirty.phone !== undefined}
                       onChange={(v) => markDirty(personId, 'phone', v)}
+                      isEditMode={isEditMode}
                     />
                   </Table.Td>
                   <Table.Td>
@@ -183,93 +200,104 @@ export default function ContactPersonsPanel({ contactId, contacts }) {
                       }
                       isDirty={dirty.mobile !== undefined}
                       onChange={(v) => markDirty(personId, 'mobile', v)}
+                      isEditMode={isEditMode}
                     />
                   </Table.Td>
                   <Table.Td ta="center">
-                    <ActionIcon
-                      variant="subtle"
-                      size="sm"
-                      color={isPrimary ? 'yellow' : 'gray'}
-                      onClick={() =>
-                        markDirty(personId, 'is_primary_contact', !isPrimary)
-                      }
-                      aria-label="Toggle primary contact"
-                    >
-                      {isPrimary ? '★' : '☆'}
-                    </ActionIcon>
+                    {isEditMode ? (
+                      <ActionIcon
+                        variant="subtle"
+                        size="sm"
+                        color={isPrimary ? 'yellow' : 'gray'}
+                        onClick={() =>
+                          markDirty(personId, 'is_primary_contact', !isPrimary)
+                        }
+                        aria-label="Toggle primary contact"
+                      >
+                        {isPrimary ? '★' : '☆'}
+                      </ActionIcon>
+                    ) : (
+                      <Text size="xs">{isPrimary ? '★' : ''}</Text>
+                    )}
                   </Table.Td>
                   <Table.Td ta="center">
                     <Checkbox
                       checked={enablePortal}
-                      onChange={(e) =>
-                        markDirty(
-                          personId,
-                          'enable_portal',
-                          e.currentTarget.checked
-                        )
+                      onChange={
+                        isEditMode
+                          ? (e) =>
+                              markDirty(
+                                personId,
+                                'enable_portal',
+                                e.currentTarget.checked
+                              )
+                          : undefined
                       }
+                      readOnly={!isEditMode}
                       size="xs"
                     />
                   </Table.Td>
-                  <Table.Td>
-                    {isConfirming ? (
-                      <Group gap={4} wrap="nowrap">
-                        <Text size="xs" c="red">
-                          Delete?
-                        </Text>
-                        <Button
-                          size="compact-xs"
-                          color="red"
-                          onClick={() => handleDelete(personId)}
-                        >
-                          Yes
-                        </Button>
-                        <Button
-                          size="compact-xs"
-                          variant="default"
-                          onClick={() => setConfirmingDelete(null)}
-                        >
-                          No
-                        </Button>
-                      </Group>
-                    ) : (
-                      <Group gap={4} wrap="nowrap">
-                        {isDirtyRow && (
+                  {isEditMode && (
+                    <Table.Td>
+                      {isConfirming ? (
+                        <Group gap={4} wrap="nowrap">
+                          <Text size="xs" c="red">
+                            Delete?
+                          </Text>
                           <Button
                             size="compact-xs"
-                            color="orange"
-                            onClick={() => handleSave(p)}
+                            color="red"
+                            onClick={() => handleDelete(personId)}
                           >
-                            Save
+                            Yes
                           </Button>
-                        )}
-                        <Button
-                          size="compact-xs"
-                          color="red"
-                          variant="subtle"
-                          onClick={() => setConfirmingDelete(personId)}
-                        >
-                          Delete
-                        </Button>
-                      </Group>
-                    )}
-                  </Table.Td>
+                          <Button
+                            size="compact-xs"
+                            variant="default"
+                            onClick={() => setConfirmingDelete(null)}
+                          >
+                            No
+                          </Button>
+                        </Group>
+                      ) : (
+                        <Group gap={4} wrap="nowrap">
+                          {isDirtyRow && (
+                            <Button
+                              size="compact-xs"
+                              color="orange"
+                              onClick={() => handleSave(p)}
+                            >
+                              Save
+                            </Button>
+                          )}
+                          <Button
+                            size="compact-xs"
+                            color="red"
+                            variant="subtle"
+                            onClick={() => setConfirmingDelete(personId)}
+                          >
+                            Delete
+                          </Button>
+                        </Group>
+                      )}
+                    </Table.Td>
+                  )}
                 </Table.Tr>
               )
             })}
-            {showAdd && (
+            {isEditMode && showAdd && (
               <AddContactPersonRow
                 contactId={contactId}
                 contacts={contacts}
-                colSpan={8}
+                colSpan={colCount}
                 onCancel={() => setShowAdd(false)}
               />
             )}
           </Table.Tbody>
-          {!showAdd && (
+          {isEditMode && !showAdd && (
             <Table.Tfoot>
               <Table.Tr>
-                <Table.Td colSpan={8}>
+                <Table.Td colSpan={colCount}>
                   <Button
                     variant="subtle"
                     size="compact-xs"

--- a/src/components/CustomerTable.jsx
+++ b/src/components/CustomerTable.jsx
@@ -15,6 +15,7 @@ import {
   Text,
 } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
+import { useQueryClient } from '@tanstack/react-query'
 import { useZohoAuth } from '../hooks/useZohoAuth.jsx'
 import { useCustomers, useUpdateContact } from '../hooks/useCustomers.js'
 import EditableCell from './EditableCell.jsx'
@@ -151,6 +152,7 @@ function ColumnHeader({ label, columnId, type, onTypeChange }) {
 
 export default function CustomerTable() {
   const { logout, orgs, orgId } = useZohoAuth()
+  const queryClient = useQueryClient()
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(getStoredPageSize)
   const { data, isLoading, isFetching, isError, error } = useCustomers({
@@ -298,22 +300,30 @@ export default function CustomerTable() {
         id: 'expander',
         header: '',
         meta: { noTypeSelector: true },
-        cell: ({ row }) => (
-          <button
-            onClick={() => toggleExpanded(row.id)}
-            style={{
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              fontSize: '0.7rem',
-              padding: '0 4px',
-              color: '#666',
-            }}
-            aria-label={expandedRows.has(row.id) ? 'Collapse' : 'Expand'}
-          >
-            {expandedRows.has(row.id) ? '▼' : '▶'}
-          </button>
-        ),
+        cell: ({ row }) => {
+          const cached = queryClient.getQueryData(['contactPersons', row.id])
+          const count = cached?.length
+          return (
+            <button
+              onClick={() => toggleExpanded(row.id)}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                fontSize: '0.7rem',
+                padding: '0 4px',
+                color: '#666',
+                whiteSpace: 'nowrap',
+              }}
+              aria-label={expandedRows.has(row.id) ? 'Collapse' : 'Expand'}
+            >
+              {expandedRows.has(row.id) ? '▼' : '▶'}
+              {count !== undefined && (
+                <span style={{ marginLeft: 3 }}>{count}</span>
+              )}
+            </button>
+          )
+        },
       },
       {
         accessorKey: 'first_name',
@@ -348,7 +358,7 @@ export default function CustomerTable() {
       },
       ...customFieldColumns,
     ],
-    [customFieldColumns, expandedRows, toggleExpanded]
+    [customFieldColumns, expandedRows, toggleExpanded, queryClient]
   )
 
   /** Collect all enum values for a column from currently-loaded contacts */
@@ -621,6 +631,7 @@ export default function CustomerTable() {
                         <ContactPersonsPanel
                           contactId={row.id}
                           contacts={contacts}
+                          isEditMode={isEditMode}
                         />
                       </Table.Td>
                     </Table.Tr>


### PR DESCRIPTION
## Summary

- **View mode**: contact persons render as plain text — no inputs, no Save/Delete/+ Add
- **Edit mode**: full editable cells, per-row save, delete with confirm, + Add from customer picker
- **Expander button**: shows `▶ 3` once a row has been expanded (reads from TanStack Query cache, no extra fetches)

## Test plan

- [ ] In view mode: expand a row → plain text, no action buttons visible
- [ ] In edit mode: expand a row → editable cells, Save/Delete/+ Add all visible
- [ ] Expander shows count after first expand; persists when collapsed

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)