### PR TITLE
feat: persist auth token in cookie to survive page reloads

### DIFF
--- a/src/hooks/useZohoAuth.jsx
+++ b/src/hooks/useZohoAuth.jsx
@@ -18,19 +18,26 @@ const SCOPES = [
 
 function loadSession() {
   try {
-    const raw = sessionStorage.getItem(SESSION_KEY)
-    return raw ? JSON.parse(raw) : null
+    const match = document.cookie
+      .split('; ')
+      .find((c) => c.startsWith(SESSION_KEY + '='))
+    if (!match) return null
+    return JSON.parse(decodeURIComponent(match.slice(SESSION_KEY.length + 1)))
   } catch {
     return null
   }
 }
 
 function saveSession(session) {
-  sessionStorage.setItem(SESSION_KEY, JSON.stringify(session))
+  const maxAge = Math.max(
+    0,
+    Math.floor((session.expiresAt - Date.now()) / 1000)
+  )
+  document.cookie = `${SESSION_KEY}=${encodeURIComponent(JSON.stringify(session))}; max-age=${maxAge}; SameSite=Strict; path=/`
 }
 
 function clearSession() {
-  sessionStorage.removeItem(SESSION_KEY)
+  document.cookie = `${SESSION_KEY}=; max-age=0; SameSite=Strict; path=/`
   sessionStorage.removeItem(AUTH_STATE_KEY)
 }
 


### PR DESCRIPTION
## Summary

Replaces `sessionStorage` with a cookie for the Zoho session token so users stay logged in across page reloads and new tabs.

- Cookie `max-age` is set to the token's remaining lifetime — auto-expires with the token (1 hour from login)
- `clearSession()` sets `max-age=0` on logout to immediately remove the cookie
- `AUTH_STATE_KEY` (temporary OAuth redirect state) remains in `sessionStorage` — only needs to survive the redirect
- Cookie flags: `SameSite=Strict; path=/`

Only `loadSession`, `saveSession`, and `clearSession` in `useZohoAuth.jsx` are changed — all other logic is untouched.

## Test plan

- [ ] Log in → refresh the page → still authenticated, no redirect to login
- [ ] Log in → open a new tab to the same URL → still authenticated
- [ ] Log out → refresh → redirected to login
- [ ] Log in → wait for token to expire (1h) → auto-logged out as before

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)