### PR TITLE
fix: remove max-width cap so table fills available screen width

### DIFF
--- a/src/components/CustomerTable.jsx
+++ b/src/components/CustomerTable.jsx
@@ -507,7 +507,7 @@ export default function CustomerTable() {
   const orgName = orgs.find((o) => o.organization_id === orgId)?.name ?? orgId
 
   return (
-    <Stack p="lg" maw={1200} mx="auto" gap="md">
+    <Stack p="lg" gap="md">
       <Group justify="space-between" align="flex-start">
         <Stack gap={4}>
           <Text fw={700} size="xl">


### PR DESCRIPTION
## Summary

Removes `maw={1200}` and `mx="auto"` from the outer `Stack` in `CustomerTable.jsx`. The table now expands to fill the viewport on wide screens. The inner `overflowX: auto` wrapper remains for cases where the table genuinely overflows (many columns, small screen).

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)