### PR TITLE
fix: trim org objects to id+name before storing in session cookie

### DIFF
--- a/src/hooks/useZohoAuth.jsx
+++ b/src/hooks/useZohoAuth.jsx
@@ -90,7 +90,7 @@ export function ZohoAuthProvider({ children }) {
       expiresAt: Date.now() + (parseInt(expires_in) || 3600) * 1000,
       region,
       orgId: orgs[0].organization_id,
-      orgs,
+      orgs: orgs.map(({ organization_id, name }) => ({ organization_id, name })),
     }
 
     saveSession(newSession)

--- a/src/hooks/useZohoAuth.jsx
+++ b/src/hooks/useZohoAuth.jsx
@@ -90,7 +90,10 @@ export function ZohoAuthProvider({ children }) {
       expiresAt: Date.now() + (parseInt(expires_in) || 3600) * 1000,
       region,
       orgId: orgs[0].organization_id,
-      orgs: orgs.map(({ organization_id, name }) => ({ organization_id, name })),
+      orgs: orgs.map(({ organization_id, name }) => ({
+        organization_id,
+        name,
+      })),
     }
 
     saveSession(newSession)


### PR DESCRIPTION
## Summary

- Zoho org objects contain 30+ fields (address, timezone, currency details, etc.)
- After `JSON.stringify` + `encodeURIComponent`, the full org array can push the `zoho_session` cookie over the 4KB browser limit
- Browsers silently drop oversized cookies, so `loadSession()` returns `null` on every page load and the user is redirected to `/login`
- Fix: store only `organization_id` and `name` per org — the only two fields the app reads from the orgs array

Closes #41

## Test plan

- [ ] Log in — confirm redirect to the main table
- [ ] Reload the page — confirm you remain logged in (no redirect to `/login`)
- [ ] Open DevTools → Application → Cookies and confirm `zoho_session` is present and well under 4KB