### PR TITLE
feat: add per-field and per-row revert buttons in edit mode

### DIFF
--- a/src/components/ContactPersonsPanel.jsx
+++ b/src/components/ContactPersonsPanel.jsx
@@ -15,22 +15,36 @@ import {
 } from '../hooks/useContactPersons.js'
 import AddContactPersonRow from './AddContactPersonRow.jsx'
 
-function PersonCell({ value, isDirty, onChange, isEditMode }) {
+function PersonCell({ value, isDirty, onChange, onRevert, isEditMode }) {
   if (!isEditMode) {
     return <Text size="xs">{value}</Text>
   }
   return (
-    <TextInput
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      size="xs"
-      styles={{
-        input: {
-          borderColor: isDirty ? '#f59e0b' : undefined,
-          backgroundColor: isDirty ? '#fefce8' : undefined,
-        },
-      }}
-    />
+    <Group gap={4} wrap="nowrap">
+      <TextInput
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        size="xs"
+        style={{ flex: 1 }}
+        styles={{
+          input: {
+            borderColor: isDirty ? '#f59e0b' : undefined,
+            backgroundColor: isDirty ? '#fefce8' : undefined,
+          },
+        }}
+      />
+      {isDirty && onRevert && (
+        <ActionIcon
+          variant="subtle"
+          color="orange"
+          size="xs"
+          onClick={onRevert}
+          aria-label="Revert"
+        >
+          ×
+        </ActionIcon>
+      )}
+    </Group>
   )
 }
 
@@ -56,7 +70,18 @@ export default function ContactPersonsPanel({
     }))
   }, [])
 
-  const clearPersonDirty = useCallback((personId) => {
+  const revertField = useCallback((personId, field) => {
+    setPersonDirtyMap((prev) => {
+      const fields = { ...(prev[personId] ?? {}) }
+      delete fields[field]
+      const next = { ...prev }
+      if (Object.keys(fields).length === 0) delete next[personId]
+      else next[personId] = fields
+      return next
+    })
+  }, [])
+
+  const revertRow = useCallback((personId) => {
     setPersonDirtyMap((prev) => {
       const next = { ...prev }
       delete next[personId]
@@ -78,7 +103,7 @@ export default function ContactPersonsPanel({
       enable_portal: dirty.enable_portal ?? person.enable_portal ?? false,
     }
     await savePerson({ personId, payload })
-    clearPersonDirty(personId)
+    revertRow(personId)
   }
 
   async function handleDelete(personId) {
@@ -152,6 +177,7 @@ export default function ContactPersonsPanel({
                       }
                       isDirty={dirty.first_name !== undefined}
                       onChange={(v) => markDirty(personId, 'first_name', v)}
+                      onRevert={() => revertField(personId, 'first_name')}
                       isEditMode={isEditMode}
                     />
                   </Table.Td>
@@ -164,6 +190,7 @@ export default function ContactPersonsPanel({
                       }
                       isDirty={dirty.last_name !== undefined}
                       onChange={(v) => markDirty(personId, 'last_name', v)}
+                      onRevert={() => revertField(personId, 'last_name')}
                       isEditMode={isEditMode}
                     />
                   </Table.Td>
@@ -176,6 +203,7 @@ export default function ContactPersonsPanel({
                       }
                       isDirty={dirty.email !== undefined}
                       onChange={(v) => markDirty(personId, 'email', v)}
+                      onRevert={() => revertField(personId, 'email')}
                       isEditMode={isEditMode}
                     />
                   </Table.Td>
@@ -188,6 +216,7 @@ export default function ContactPersonsPanel({
                       }
                       isDirty={dirty.phone !== undefined}
                       onChange={(v) => markDirty(personId, 'phone', v)}
+                      onRevert={() => revertField(personId, 'phone')}
                       isEditMode={isEditMode}
                     />
                   </Table.Td>
@@ -200,42 +229,75 @@ export default function ContactPersonsPanel({
                       }
                       isDirty={dirty.mobile !== undefined}
                       onChange={(v) => markDirty(personId, 'mobile', v)}
+                      onRevert={() => revertField(personId, 'mobile')}
                       isEditMode={isEditMode}
                     />
                   </Table.Td>
                   <Table.Td ta="center">
                     {isEditMode ? (
-                      <ActionIcon
-                        variant="subtle"
-                        size="sm"
-                        color={isPrimary ? 'yellow' : 'gray'}
-                        onClick={() =>
-                          markDirty(personId, 'is_primary_contact', !isPrimary)
-                        }
-                        aria-label="Toggle primary contact"
-                      >
-                        {isPrimary ? '★' : '☆'}
-                      </ActionIcon>
+                      <Group gap={2} justify="center">
+                        <ActionIcon
+                          variant="subtle"
+                          size="sm"
+                          color={isPrimary ? 'yellow' : 'gray'}
+                          onClick={() =>
+                            markDirty(
+                              personId,
+                              'is_primary_contact',
+                              !isPrimary
+                            )
+                          }
+                          aria-label="Toggle primary contact"
+                        >
+                          {isPrimary ? '★' : '☆'}
+                        </ActionIcon>
+                        {dirty.is_primary_contact !== undefined && (
+                          <ActionIcon
+                            variant="subtle"
+                            color="orange"
+                            size="xs"
+                            onClick={() =>
+                              revertField(personId, 'is_primary_contact')
+                            }
+                            aria-label="Revert"
+                          >
+                            ×
+                          </ActionIcon>
+                        )}
+                      </Group>
                     ) : (
                       <Text size="xs">{isPrimary ? '★' : ''}</Text>
                     )}
                   </Table.Td>
                   <Table.Td ta="center">
-                    <Checkbox
-                      checked={enablePortal}
-                      onChange={
-                        isEditMode
-                          ? (e) =>
-                              markDirty(
-                                personId,
-                                'enable_portal',
-                                e.currentTarget.checked
-                              )
-                          : undefined
-                      }
-                      readOnly={!isEditMode}
-                      size="xs"
-                    />
+                    <Group gap={2} justify="center">
+                      <Checkbox
+                        checked={enablePortal}
+                        onChange={
+                          isEditMode
+                            ? (e) =>
+                                markDirty(
+                                  personId,
+                                  'enable_portal',
+                                  e.currentTarget.checked
+                                )
+                            : undefined
+                        }
+                        readOnly={!isEditMode}
+                        size="xs"
+                      />
+                      {isEditMode && dirty.enable_portal !== undefined && (
+                        <ActionIcon
+                          variant="subtle"
+                          color="orange"
+                          size="xs"
+                          onClick={() => revertField(personId, 'enable_portal')}
+                          aria-label="Revert"
+                        >
+                          ×
+                        </ActionIcon>
+                      )}
+                    </Group>
                   </Table.Td>
                   {isEditMode && (
                     <Table.Td>
@@ -262,13 +324,23 @@ export default function ContactPersonsPanel({
                       ) : (
                         <Group gap={4} wrap="nowrap">
                           {isDirtyRow && (
-                            <Button
-                              size="compact-xs"
-                              color="orange"
-                              onClick={() => handleSave(p)}
-                            >
-                              Save
-                            </Button>
+                            <>
+                              <Button
+                                size="compact-xs"
+                                color="orange"
+                                onClick={() => handleSave(p)}
+                              >
+                                Save
+                              </Button>
+                              <Button
+                                size="compact-xs"
+                                variant="subtle"
+                                color="orange"
+                                onClick={() => revertRow(personId)}
+                              >
+                                Revert
+                              </Button>
+                            </>
                           )}
                           <Button
                             size="compact-xs"

--- a/src/components/EditableCell.jsx
+++ b/src/components/EditableCell.jsx
@@ -1,5 +1,14 @@
 import { useState } from 'react'
-import { Anchor, Checkbox, Select, Stack, Text, TextInput } from '@mantine/core'
+import {
+  ActionIcon,
+  Anchor,
+  Checkbox,
+  Group,
+  Select,
+  Stack,
+  Text,
+  TextInput,
+} from '@mantine/core'
 import { DateInput } from '@mantine/dates'
 
 const ADD_NEW_SENTINEL = '__add_new__'
@@ -57,6 +66,13 @@ export default function EditableCell({ getValue, row, column, table }) {
     } else {
       meta.clearValidationError?.(contactId, columnId)
     }
+  }
+
+  function handleRevert() {
+    meta.clearDirty(contactId, columnId)
+    setValue(initialValue)
+    setAddingNew(false)
+    reportValidationError(null)
   }
 
   // --- Shared blur handler for text/email/phone/url ---
@@ -123,17 +139,30 @@ export default function EditableCell({ getValue, row, column, table }) {
 
     return (
       <Stack gap={2}>
-        <Checkbox
-          checked={boolValue}
-          onChange={handleCheckboxChange}
-          size="xs"
-          styles={{
-            input: {
-              cursor: 'pointer',
-              borderColor: isDirty ? '#f59e0b' : undefined,
-            },
-          }}
-        />
+        <Group gap={4} align="center">
+          <Checkbox
+            checked={boolValue}
+            onChange={handleCheckboxChange}
+            size="xs"
+            styles={{
+              input: {
+                cursor: 'pointer',
+                borderColor: isDirty ? '#f59e0b' : undefined,
+              },
+            }}
+          />
+          {isDirty && (
+            <ActionIcon
+              variant="subtle"
+              color="orange"
+              size="xs"
+              onClick={handleRevert}
+              aria-label="Revert"
+            >
+              ×
+            </ActionIcon>
+          )}
+        </Group>
         {isDirty && (
           <Text size="xs" c="dimmed" fs="italic">
             was:{' '}
@@ -171,21 +200,36 @@ export default function EditableCell({ getValue, row, column, table }) {
 
     return (
       <Stack gap={2}>
-        <DateInput
-          value={validDateValue}
-          onChange={handleDateChange}
-          size="xs"
-          error={validationError}
-          clearable
-          valueFormat="YYYY-MM-DD"
-          styles={{
-            input: {
-              borderColor: isDirty && !validationError ? '#f59e0b' : undefined,
-              backgroundColor:
-                isDirty && !validationError ? '#fefce8' : undefined,
-            },
-          }}
-        />
+        <Group gap={4} align="flex-start">
+          <DateInput
+            value={validDateValue}
+            onChange={handleDateChange}
+            size="xs"
+            error={validationError}
+            clearable
+            valueFormat="YYYY-MM-DD"
+            styles={{
+              input: {
+                borderColor:
+                  isDirty && !validationError ? '#f59e0b' : undefined,
+                backgroundColor:
+                  isDirty && !validationError ? '#fefce8' : undefined,
+              },
+            }}
+          />
+          {isDirty && (
+            <ActionIcon
+              variant="subtle"
+              color="orange"
+              size="xs"
+              onClick={handleRevert}
+              aria-label="Revert"
+              style={{ marginTop: 4 }}
+            >
+              ×
+            </ActionIcon>
+          )}
+        </Group>
         {isDirty && !validationError && (
           <Text size="xs" c="dimmed" fs="italic">
             was: {originalValue}
@@ -246,37 +290,53 @@ export default function EditableCell({ getValue, row, column, table }) {
 
     return (
       <Stack gap={2}>
-        {addingNew ? (
-          <TextInput
-            autoFocus
-            value={newEnumValue}
-            onChange={(e) => setNewEnumValue(e.target.value)}
-            onBlur={handleNewEnumBlur}
-            placeholder="Type new value…"
-            size="xs"
-            styles={{
-              input: {
-                borderColor: isDirty ? '#f59e0b' : undefined,
-                backgroundColor: isDirty ? '#fefce8' : undefined,
-              },
-            }}
-          />
-        ) : (
-          <Select
-            value={selectValue || null}
-            onChange={handleSelectChange}
-            data={selectData}
-            size="xs"
-            allowDeselect={false}
-            comboboxProps={{ withinPortal: true }}
-            styles={{
-              input: {
-                borderColor: isDirty ? '#f59e0b' : undefined,
-                backgroundColor: isDirty ? '#fefce8' : undefined,
-              },
-            }}
-          />
-        )}
+        <Group gap={4} align="flex-start">
+          {addingNew ? (
+            <TextInput
+              autoFocus
+              value={newEnumValue}
+              onChange={(e) => setNewEnumValue(e.target.value)}
+              onBlur={handleNewEnumBlur}
+              placeholder="Type new value…"
+              size="xs"
+              style={{ flex: 1 }}
+              styles={{
+                input: {
+                  borderColor: isDirty ? '#f59e0b' : undefined,
+                  backgroundColor: isDirty ? '#fefce8' : undefined,
+                },
+              }}
+            />
+          ) : (
+            <Select
+              value={selectValue || null}
+              onChange={handleSelectChange}
+              data={selectData}
+              size="xs"
+              allowDeselect={false}
+              comboboxProps={{ withinPortal: true }}
+              style={{ flex: 1 }}
+              styles={{
+                input: {
+                  borderColor: isDirty ? '#f59e0b' : undefined,
+                  backgroundColor: isDirty ? '#fefce8' : undefined,
+                },
+              }}
+            />
+          )}
+          {isDirty && (
+            <ActionIcon
+              variant="subtle"
+              color="orange"
+              size="xs"
+              onClick={handleRevert}
+              aria-label="Revert"
+              style={{ marginTop: 4 }}
+            >
+              ×
+            </ActionIcon>
+          )}
+        </Group>
         {isDirty && (
           <Text size="xs" c="dimmed" fs="italic">
             was: {originalValue}
@@ -298,21 +358,36 @@ export default function EditableCell({ getValue, row, column, table }) {
 
   return (
     <Stack gap={2}>
-      <TextInput
-        type={inputType}
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onBlur={handleBlur}
-        error={validationError}
-        size="xs"
-        styles={{
-          input: {
-            borderColor: isDirty && !validationError ? '#f59e0b' : undefined,
-            backgroundColor:
-              isDirty && !validationError ? '#fefce8' : undefined,
-          },
-        }}
-      />
+      <Group gap={4} align="flex-start">
+        <TextInput
+          type={inputType}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onBlur={handleBlur}
+          error={validationError}
+          size="xs"
+          style={{ flex: 1 }}
+          styles={{
+            input: {
+              borderColor: isDirty && !validationError ? '#f59e0b' : undefined,
+              backgroundColor:
+                isDirty && !validationError ? '#fefce8' : undefined,
+            },
+          }}
+        />
+        {isDirty && (
+          <ActionIcon
+            variant="subtle"
+            color="orange"
+            size="xs"
+            onClick={handleRevert}
+            aria-label="Revert"
+            style={{ marginTop: 4 }}
+          >
+            ×
+          </ActionIcon>
+        )}
+      </Group>
       {isDirty && !validationError && (
         <Text size="xs" c="dimmed" fs="italic">
           was: {originalValue}


### PR DESCRIPTION
## Summary

Adds granular revert controls so users can undo individual changes without hitting the global Cancel.

### Customer cells (`EditableCell`)
- A `×` button appears inline with any dirty input (all cell types: text, email, phone, date, enum, boolean)
- Clicking it clears that field from `dirtyMap` and resets local state — no API call

### Contact person cells (`ContactPersonsPanel`)
- Each dirty text field shows a `×` button next to the input
- The Primary and Notify columns also show `×` when dirty
- A "Revert" button appears in the row's actions column alongside "Save" whenever any field in the row has unsaved changes; clicking it clears all dirty fields for that person at once

## Test plan
- [ ] Edit a customer cell → `×` appears → click → field reverts, "was:" label disappears
- [ ] Edit a contact person field → `×` appears → click → that field reverts, others unchanged
- [ ] Edit multiple person fields → click "Revert" row button → all fields for that person revert
- [ ] Other dirty cells are unaffected by a targeted revert
- [ ] Cancel still discards everything as before

Closes #44