### PR TITLE
feat: show contact person count on expander before row is opened

### DIFF
--- a/src/components/CustomerTable.jsx
+++ b/src/components/CustomerTable.jsx
@@ -302,7 +302,10 @@ export default function CustomerTable() {
         meta: { noTypeSelector: true },
         cell: ({ row }) => {
           const cached = queryClient.getQueryData(['contactPersons', row.id])
-          const count = cached?.length
+          // cached takes precedence (accurate after first expand); fall back to
+          // the count Zoho returns inline with the contacts list response
+          const count =
+            cached?.length ?? row.original.contact_persons?.length
           return (
             <button
               onClick={() => toggleExpanded(row.id)}

--- a/src/components/CustomerTable.jsx
+++ b/src/components/CustomerTable.jsx
@@ -304,8 +304,7 @@ export default function CustomerTable() {
           const cached = queryClient.getQueryData(['contactPersons', row.id])
           // cached takes precedence (accurate after first expand); fall back to
           // the count Zoho returns inline with the contacts list response
-          const count =
-            cached?.length ?? row.original.contact_persons?.length
+          const count = cached?.length ?? row.original.contact_persons?.length
           return (
             <button
               onClick={() => toggleExpanded(row.id)}


### PR DESCRIPTION
## Summary

The Zoho contacts list response includes a `contact_persons` array on each contact object. This PR uses its length as the initial count shown on the `▶` expander button, so every row displays a count from the moment the page loads — no expand required.

The TanStack Query cache (populated after the first expand) continues to take precedence, keeping the count accurate after mutations without a page reload.

## Test plan
- [ ] Load the page → each row with contact persons shows a number next to its `▶` before clicking
- [ ] Expand a row → count still shown correctly
- [ ] Add or remove a contact person → count updates after the cache is invalidated

Closes #46