### PR TITLE
feat: add CSV import mode with column mapping and match key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lions-portal-zoho-invoice-sync",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lions-portal-zoho-invoice-sync",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "dependencies": {
         "@mantine/core": "^8.3.18",
         "@mantine/dates": "^8.3.18",
@@ -14,6 +14,7 @@
         "@mantine/modals": "^8.3.18",
         "@tanstack/react-query": "^5.62.0",
         "@tanstack/react-table": "^8.20.5",
+        "papaparse": "^5.4.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.28.0"
@@ -10656,6 +10657,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@tanstack/react-table": "^8.20.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "papaparse": "^5.4.1",
     "react-router-dom": "^6.28.0"
   },
   "devDependencies": {

--- a/src/components/CsvImportModal.jsx
+++ b/src/components/CsvImportModal.jsx
@@ -1,0 +1,315 @@
+import { useEffect, useRef, useState } from 'react'
+import Papa from 'papaparse'
+import {
+  Alert,
+  Button,
+  Group,
+  Modal,
+  ScrollArea,
+  Select,
+  Stack,
+  Table,
+  Text,
+} from '@mantine/core'
+import {
+  STANDARD_ZOHO_FIELDS,
+  applyMapping,
+  initialMapping,
+  loadSavedMatchKey,
+  saveMapping,
+  saveMatchKey,
+} from '../lib/csvImport.js'
+
+/**
+ * CsvImportModal — two-step CSV import: upload → column mapping → apply.
+ *
+ * Props:
+ *   opened          {boolean}
+ *   onClose         {() => void}
+ *   contacts        {Object[]}  — currently loaded Zoho contacts
+ *   customFields    {Array<{api_name, label}>}  — from first contact
+ *   onApply         {(dirtyMap: Object) => void}
+ */
+export default function CsvImportModal({
+  opened,
+  onClose,
+  contacts,
+  customFields,
+  onApply,
+}) {
+  const fileInputRef = useRef(null)
+
+  // Step: 'upload' | 'mapping'
+  const [step, setStep] = useState('upload')
+
+  // Parsed CSV state
+  const [csvHeaders, setCsvHeaders] = useState([])
+  const [csvRows, setCsvRows] = useState([])
+  const [parseError, setParseError] = useState(null)
+
+  // Column mapping: { [csvHeader]: zohoFieldId | '__ignore__' }
+  const [mapping, setMapping] = useState({})
+
+  // Match key config
+  const [matchCsvHeader, setMatchCsvHeader] = useState(null)
+  const [matchZohoField, setMatchZohoField] = useState(null)
+
+  // Result after applying
+  const [applyResult, setApplyResult] = useState(null) // { matchedCount, unmatchedCount }
+
+  // Reset state when modal opens
+  useEffect(() => {
+    if (opened) {
+      setStep('upload')
+      setCsvHeaders([])
+      setCsvRows([])
+      setParseError(null)
+      setMapping({})
+      setApplyResult(null)
+      // Restore saved match key
+      const saved = loadSavedMatchKey()
+      if (saved) {
+        setMatchCsvHeader(saved.csvHeader ?? null)
+        setMatchZohoField(saved.zohoField ?? null)
+      } else {
+        setMatchCsvHeader(null)
+        setMatchZohoField(null)
+      }
+    }
+  }, [opened])
+
+  // Zoho field options for the mapping dropdowns
+  const zohoFieldOptions = [
+    { value: '__ignore__', label: 'Ignore' },
+    ...STANDARD_ZOHO_FIELDS,
+    ...(customFields ?? []).map((cf) => ({
+      value: cf.api_name,
+      label: cf.label ?? cf.api_name,
+    })),
+  ]
+
+  function handleFileChange(e) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setParseError(null)
+    Papa.parse(file, {
+      header: true,
+      skipEmptyLines: true,
+      complete: (result) => {
+        if (result.errors.length > 0 && result.data.length === 0) {
+          setParseError(result.errors[0].message)
+          return
+        }
+        const headers = result.meta.fields ?? []
+        setCsvHeaders(headers)
+        setCsvRows(result.data)
+        const m = initialMapping(headers)
+        setMapping(m)
+
+        // Auto-select match key if saved one is present in this file's headers
+        const saved = loadSavedMatchKey()
+        if (saved && headers.includes(saved.csvHeader)) {
+          setMatchCsvHeader(saved.csvHeader)
+          setMatchZohoField(saved.zohoField)
+        }
+
+        setStep('mapping')
+      },
+      error: (err) => {
+        setParseError(err.message)
+      },
+    })
+    // Reset file input so the same file can be re-selected
+    e.target.value = ''
+  }
+
+  function handleMappingChange(csvHeader, zohoField) {
+    setMapping((prev) => ({ ...prev, [csvHeader]: zohoField }))
+  }
+
+  function handleMatchCsvHeaderChange(val) {
+    setMatchCsvHeader(val)
+    // Auto-fill the Zoho match field from the current column mapping
+    const mapped = mapping[val]
+    if (mapped && mapped !== '__ignore__') {
+      setMatchZohoField(mapped)
+    }
+  }
+
+  function handleApply() {
+    if (!matchCsvHeader || !matchZohoField) return
+
+    saveMapping(mapping)
+    saveMatchKey(matchCsvHeader, matchZohoField)
+
+    const { dirtyMap, matchedCount, unmatchedCount } = applyMapping(
+      csvRows,
+      mapping,
+      matchCsvHeader,
+      matchZohoField,
+      contacts
+    )
+
+    setApplyResult({ matchedCount, unmatchedCount })
+
+    if (unmatchedCount > 0 && matchedCount === 0) {
+      // Nothing matched — show warning, don't close yet
+      return
+    }
+
+    onApply(dirtyMap)
+    onClose()
+  }
+
+  // Example value for a CSV header (first non-empty row)
+  function exampleValue(header) {
+    for (const row of csvRows) {
+      const v = row[header]
+      if (v != null && String(v).trim() !== '') return String(v).trim()
+    }
+    return ''
+  }
+
+  const canApply = matchCsvHeader && matchZohoField
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title="Import from CSV"
+      size="xl"
+      scrollAreaComponent={ScrollArea.Autosize}
+    >
+      {step === 'upload' && (
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            Upload a CSV file. Headers will be analyzed and mapped to Zoho
+            contact fields automatically where possible.
+          </Text>
+          {parseError && (
+            <Alert color="red" title="Parse error">
+              {parseError}
+            </Alert>
+          )}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".csv,text/csv"
+            style={{ display: 'none' }}
+            onChange={handleFileChange}
+          />
+          <Button onClick={() => fileInputRef.current?.click()}>
+            Choose CSV file…
+          </Button>
+          <Group justify="flex-end">
+            <Button variant="default" onClick={onClose}>
+              Cancel
+            </Button>
+          </Group>
+        </Stack>
+      )}
+
+      {step === 'mapping' && (
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            {csvRows.length} rows loaded. Map CSV columns to Zoho fields below,
+            then choose the column used to identify each contact.
+          </Text>
+
+          {/* Match key config */}
+          <Stack gap={4}>
+            <Text size="sm" fw={600}>
+              Match key
+            </Text>
+            <Text size="xs" c="dimmed">
+              Which CSV column uniquely identifies a contact, and which Zoho
+              field to compare it against?
+            </Text>
+            <Group gap="sm" align="flex-end">
+              <Select
+                label="CSV column"
+                placeholder="Select…"
+                size="xs"
+                w={240}
+                value={matchCsvHeader}
+                onChange={handleMatchCsvHeaderChange}
+                data={csvHeaders}
+                searchable
+              />
+              <Select
+                label="Zoho field"
+                placeholder="Select…"
+                size="xs"
+                w={200}
+                value={matchZohoField}
+                onChange={setMatchZohoField}
+                data={zohoFieldOptions.filter((o) => o.value !== '__ignore__')}
+                searchable
+              />
+            </Group>
+          </Stack>
+
+          {/* Column mapping table */}
+          <Table fz="xs" withTableBorder withColumnBorders>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>CSV Column</Table.Th>
+                <Table.Th>Example Value</Table.Th>
+                <Table.Th>→ Zoho Field</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {csvHeaders.map((header) => (
+                <Table.Tr key={header}>
+                  <Table.Td>
+                    <Text size="xs">{header}</Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Text size="xs" c="dimmed">
+                      {exampleValue(header)}
+                    </Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Select
+                      size="xs"
+                      value={mapping[header] ?? '__ignore__'}
+                      onChange={(val) =>
+                        val && handleMappingChange(header, val)
+                      }
+                      data={zohoFieldOptions}
+                      allowDeselect={false}
+                      comboboxProps={{ withinPortal: true }}
+                    />
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+
+          {applyResult && applyResult.unmatchedCount > 0 && (
+            <Alert
+              color={applyResult.matchedCount === 0 ? 'red' : 'yellow'}
+              title="Unmatched rows"
+            >
+              {applyResult.unmatchedCount} row
+              {applyResult.unmatchedCount !== 1 ? 's' : ''} could not be matched
+              to a Zoho contact.
+              {applyResult.matchedCount === 0
+                ? ' No contacts were updated. Check your match key configuration.'
+                : ' Matched rows have been applied.'}
+            </Alert>
+          )}
+
+          <Group justify="flex-end" gap="sm">
+            <Button variant="default" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button color="orange" onClick={handleApply} disabled={!canApply}>
+              Apply mapping
+            </Button>
+          </Group>
+        </Stack>
+      )}
+    </Modal>
+  )
+}

--- a/src/components/CustomerTable.jsx
+++ b/src/components/CustomerTable.jsx
@@ -26,6 +26,16 @@ import {
 import EditableCell from './EditableCell.jsx'
 import CommitModal from './CommitModal.jsx'
 import ContactPersonsPanel from './ContactPersonsPanel.jsx'
+import CsvImportModal from './CsvImportModal.jsx'
+
+// Human-readable labels for billing sub-fields populated via CSV import
+// (these don't have a column definition in the table)
+const EXTRA_FIELD_LABELS = {
+  billing_city: 'Billing City',
+  billing_state: 'Billing State',
+  billing_zip: 'Billing Zip',
+  billing_country: 'Billing Country',
+}
 
 const PAGE_SIZE_OPTIONS = ['10', '25', '50', '100']
 const DEFAULT_PAGE_SIZE = '25'
@@ -105,6 +115,14 @@ function buildPayload(original, dirtyFields) {
       // already handled above
     } else if (field === 'address') {
       payload.billing_address.address = value
+    } else if (field === 'billing_city') {
+      payload.billing_address.city = value
+    } else if (field === 'billing_state') {
+      payload.billing_address.state = value
+    } else if (field === 'billing_zip') {
+      payload.billing_address.zip = value
+    } else if (field === 'billing_country') {
+      payload.billing_address.country = value
     } else if (field.startsWith('cf_')) {
       const idx = payload.custom_fields.findIndex((f) => f.api_name === field)
       if (idx >= 0) {
@@ -177,6 +195,10 @@ export default function CustomerTable() {
 
   // CommitModal open state
   const [modalOpened, { open: openModal, close: closeModal }] =
+    useDisclosure(false)
+
+  // CsvImportModal open state
+  const [csvModalOpened, { open: openCsvModal, close: closeCsvModal }] =
     useDisclosure(false)
 
   // Column type overrides: { [columnId]: type } — seeded from cookie on mount
@@ -512,6 +534,14 @@ export default function CustomerTable() {
         let original = ''
         if (columnId === 'address') {
           original = contact.billing_address?.address ?? ''
+        } else if (columnId === 'billing_city') {
+          original = contact.billing_address?.city ?? ''
+        } else if (columnId === 'billing_state') {
+          original = contact.billing_address?.state ?? ''
+        } else if (columnId === 'billing_zip') {
+          original = contact.billing_address?.zip ?? ''
+        } else if (columnId === 'billing_country') {
+          original = contact.billing_address?.country ?? ''
         } else if (columnId.startsWith('cf_')) {
           original =
             contact.custom_fields?.find((f) => f.api_name === columnId)
@@ -520,9 +550,10 @@ export default function CustomerTable() {
           original = contact[columnId] ?? ''
         }
 
-        // Resolve human-readable field label from column definitions
+        // Resolve human-readable field label from column definitions or fallback map
         const colDef = columns.find((c) => (c.accessorKey ?? c.id) === columnId)
-        const fieldLabel = colDef?.header ?? columnId
+        const fieldLabel =
+          colDef?.header ?? EXTRA_FIELD_LABELS[columnId] ?? columnId
 
         changes.push({
           contactId,
@@ -641,6 +672,17 @@ export default function CustomerTable() {
     setIsEditMode(true)
   }
 
+  function handleCsvApply(importedDirtyMap) {
+    setDirtyMap((prev) => {
+      const next = { ...prev }
+      for (const [contactId, fields] of Object.entries(importedDirtyMap)) {
+        next[contactId] = { ...(next[contactId] ?? {}), ...fields }
+      }
+      return next
+    })
+    setIsEditMode(true)
+  }
+
   function handlePageSizeChange(value) {
     try {
       localStorage.setItem('customerTable.pageSize', value)
@@ -695,9 +737,19 @@ export default function CustomerTable() {
         </Stack>
         <Group gap="xs" align="center">
           {!isEditMode && (
-            <Button size="sm" variant="light" onClick={enterEditMode}>
-              Edit
-            </Button>
+            <>
+              <Button size="sm" variant="light" onClick={enterEditMode}>
+                Edit
+              </Button>
+              <Button
+                size="sm"
+                variant="light"
+                color="teal"
+                onClick={openCsvModal}
+              >
+                Import from CSV
+              </Button>
+            </>
           )}
           {isEditMode && (
             <>
@@ -899,6 +951,14 @@ export default function CustomerTable() {
             0
           ),
         }}
+      />
+
+      <CsvImportModal
+        opened={csvModalOpened}
+        onClose={closeCsvModal}
+        contacts={contacts}
+        customFields={contacts[0]?.custom_fields ?? []}
+        onApply={handleCsvApply}
       />
     </Stack>
   )

--- a/src/lib/csvImport.js
+++ b/src/lib/csvImport.js
@@ -1,0 +1,178 @@
+/**
+ * CSV import utilities — pure functions, no React dependencies.
+ */
+
+/** Standard Zoho contact fields available as mapping targets. */
+export const STANDARD_ZOHO_FIELDS = [
+  { value: 'first_name', label: 'First Name' },
+  { value: 'last_name', label: 'Last Name' },
+  { value: 'email', label: 'Email' },
+  { value: 'phone', label: 'Phone' },
+  { value: 'mobile', label: 'Mobile' },
+  { value: 'address', label: 'Billing Address' },
+  { value: 'billing_city', label: 'Billing City' },
+  { value: 'billing_state', label: 'Billing State' },
+  { value: 'billing_zip', label: 'Billing Zip' },
+  { value: 'billing_country', label: 'Billing Country' },
+]
+
+/**
+ * CSV header → Zoho field auto-mapping for the Lions Club report format.
+ * Only covers headers that have a clear 1-to-1 mapping.
+ */
+export const AUTO_MAP = {
+  'Contact: First Name': 'first_name',
+  'Contact: Last Name': 'last_name',
+  'Contact: Personal Email': 'email',
+  'Contact: Mobile': 'mobile',
+  'Contact: Mailing Address Line 1': 'address',
+  'Contact: Mailing City': 'billing_city',
+  'Contact: Mailing State/Province': 'billing_state',
+  'Contact: Mailing Zip/Postal Code': 'billing_zip',
+  'Contact: Mailing Country': 'billing_country',
+}
+
+/**
+ * CSV headers that are ignored by default (no useful Zoho field equivalent).
+ * The user can still map them manually.
+ */
+export const IGNORE_BY_DEFAULT = new Set([
+  'Contact: Preferred Email',
+  'Contact: Preferred Phone',
+  'Type',
+  'Account Id',
+  'Parent Id',
+  'Parent Parent Id',
+  'Parent Multiple District',
+  'Parent District',
+  'Contact: First Name (Local)',
+  'Contact: Last Name (Local)',
+  'Contact: Local Address',
+  'Account Name (Local)',
+])
+
+const MAPPING_STORAGE_KEY = 'csvImport.mapping'
+const MATCH_KEY_STORAGE_KEY = 'csvImport.matchKey'
+
+export function loadSavedMapping() {
+  try {
+    const raw = localStorage.getItem(MAPPING_STORAGE_KEY)
+    return raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+}
+
+export function saveMapping(mapping) {
+  try {
+    localStorage.setItem(MAPPING_STORAGE_KEY, JSON.stringify(mapping))
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function loadSavedMatchKey() {
+  try {
+    const raw = localStorage.getItem(MATCH_KEY_STORAGE_KEY)
+    return raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+}
+
+export function saveMatchKey(csvHeader, zohoField) {
+  try {
+    localStorage.setItem(
+      MATCH_KEY_STORAGE_KEY,
+      JSON.stringify({ csvHeader, zohoField })
+    )
+  } catch {
+    // ignore storage errors
+  }
+}
+
+/**
+ * Build the initial column mapping for a set of CSV headers.
+ * Prefers saved mapping, falls back to AUTO_MAP, then '__ignore__'.
+ */
+export function initialMapping(headers) {
+  const saved = loadSavedMapping() ?? {}
+  return Object.fromEntries(
+    headers.map((h) => [h, saved[h] ?? AUTO_MAP[h] ?? '__ignore__'])
+  )
+}
+
+/** Read a Zoho contact's value for a given field id. */
+export function getContactFieldValue(contact, fieldId) {
+  if (fieldId === 'address') return contact.billing_address?.address ?? ''
+  if (fieldId === 'billing_city') return contact.billing_address?.city ?? ''
+  if (fieldId === 'billing_state') return contact.billing_address?.state ?? ''
+  if (fieldId === 'billing_zip') return contact.billing_address?.zip ?? ''
+  if (fieldId === 'billing_country')
+    return contact.billing_address?.country ?? ''
+  if (fieldId?.startsWith('cf_')) {
+    return (
+      contact.custom_fields?.find((f) => f.api_name === fieldId)?.value ?? ''
+    )
+  }
+  return contact[fieldId] ?? ''
+}
+
+/**
+ * Apply a column mapping to parsed CSV rows, producing dirty-map entries.
+ *
+ * @param {Object[]} csvRows - rows from PapaParse (header: true)
+ * @param {Object}   mapping - { [csvHeader]: zohoFieldId | '__ignore__' }
+ * @param {string}   matchCsvHeader - CSV column used to identify the contact
+ * @param {string}   matchZohoField - Zoho field to compare match value against
+ * @param {Object[]} contacts - loaded Zoho contacts
+ * @returns {{ dirtyMap: Object, matchedCount: number, unmatchedCount: number }}
+ *   dirtyMap: { [contactId]: { [zohoFieldId]: newValue } }
+ */
+export function applyMapping(
+  csvRows,
+  mapping,
+  matchCsvHeader,
+  matchZohoField,
+  contacts
+) {
+  const dirtyMap = {}
+  let matchedCount = 0
+  let unmatchedCount = 0
+
+  for (const row of csvRows) {
+    const matchValue = String(row[matchCsvHeader] ?? '').trim()
+    if (!matchValue) continue
+
+    const contact = contacts.find(
+      (c) =>
+        String(getContactFieldValue(c, matchZohoField)).trim() === matchValue
+    )
+
+    if (!contact) {
+      unmatchedCount++
+      continue
+    }
+
+    matchedCount++
+    const contactId = contact.contact_id
+    const fields = {}
+
+    for (const [csvHeader, zohoField] of Object.entries(mapping)) {
+      if (zohoField === '__ignore__') continue
+      const csvValue = String(row[csvHeader] ?? '').trim()
+      const currentValue = String(
+        getContactFieldValue(contact, zohoField)
+      ).trim()
+      if (csvValue !== currentValue) {
+        fields[zohoField] = csvValue
+      }
+    }
+
+    if (Object.keys(fields).length > 0) {
+      dirtyMap[contactId] = { ...(dirtyMap[contactId] ?? {}), ...fields }
+    }
+  }
+
+  return { dirtyMap, matchedCount, unmatchedCount }
+}


### PR DESCRIPTION
## Summary

- Adds an **"Import from CSV"** button visible when not in edit mode
- Two-step flow: **upload** a `.csv` file → **column mapping** UI → **apply**
- Column mapping table shows each CSV header with an example value and a dropdown to assign it to a Zoho contact field (standard fields + custom fields discovered from loaded contacts)
- A separate **match key** config selects which CSV column and Zoho field to use to identify each contact
- Matched rows populate `dirtyMap` and the user enters the normal edit / revert / commit flow; no data is written until the user clicks **Commit**
- Unmatched rows show a warning with a count
- Mapping and match key selection are persisted to `localStorage` and restored on the next import
- `buildPayload` extended to handle `billing_city`, `billing_state`, `billing_zip`, `billing_country` sub-fields set by the import
- `AUTO_MAP` auto-assigns common Lions Club report columns (First Name, Last Name, Personal Email, Mobile, Mailing Address, City, State, Zip, Country) on first use

Closes #47