### PR TITLE
fix: normalize whitespace in CSV import value comparison

### DIFF
--- a/src/lib/csvImport.js
+++ b/src/lib/csvImport.js
@@ -119,6 +119,16 @@ export function getContactFieldValue(contact, fieldId) {
 }
 
 /**
+ * Normalize a string for comparison: trim leading/trailing whitespace and
+ * collapse internal runs of whitespace to a single space.
+ */
+function normalizeWs(s) {
+  return String(s ?? '')
+    .trim()
+    .replace(/\s+/g, ' ')
+}
+
+/**
  * Apply a column mapping to parsed CSV rows, producing dirty-map entries.
  *
  * @param {Object[]} csvRows - rows from PapaParse (header: true)
@@ -141,12 +151,11 @@ export function applyMapping(
   let unmatchedCount = 0
 
   for (const row of csvRows) {
-    const matchValue = String(row[matchCsvHeader] ?? '').trim()
+    const matchValue = normalizeWs(row[matchCsvHeader])
     if (!matchValue) continue
 
     const contact = contacts.find(
-      (c) =>
-        String(getContactFieldValue(c, matchZohoField)).trim() === matchValue
+      (c) => normalizeWs(getContactFieldValue(c, matchZohoField)) === matchValue
     )
 
     if (!contact) {
@@ -160,10 +169,8 @@ export function applyMapping(
 
     for (const [csvHeader, zohoField] of Object.entries(mapping)) {
       if (zohoField === '__ignore__') continue
-      const csvValue = String(row[csvHeader] ?? '').trim()
-      const currentValue = String(
-        getContactFieldValue(contact, zohoField)
-      ).trim()
+      const csvValue = normalizeWs(row[csvHeader])
+      const currentValue = normalizeWs(getContactFieldValue(contact, zohoField))
       if (csvValue !== currentValue) {
         fields[zohoField] = csvValue
       }


### PR DESCRIPTION
## Summary

- Values that differ only in whitespace (extra spaces between words, leading/trailing spaces) were incorrectly flagged as changes during CSV import
- Adds a `normalizeWs()` helper that trims and collapses all internal whitespace runs to a single space
- Applied to both sides of every comparison in `applyMapping()`: match-key lookup and per-field dirty check
- The normalized value is also stored in the dirty map, so committed values are always clean

## Test plan

- [ ] CSV with `"John  Smith"` (double space) does not flag as a change when Zoho has `"John Smith"`
- [ ] CSV with `" Smith "` (leading/trailing spaces) matches correctly in both field comparison and match-key lookup
- [ ] Genuine changes (different name, not just whitespace) still correctly flagged as dirty
- [ ] Match-key lookup succeeds even when CSV and Zoho values differ only in whitespace

Closes #54