### PR TITLE
feat: commit progress tracking, partial retry, and persistent edit storage

### DIFF
--- a/src/components/CommitModal.jsx
+++ b/src/components/CommitModal.jsx
@@ -3,11 +3,13 @@ import {
   Alert,
   Button,
   Group,
+  Loader,
   Modal,
   ScrollArea,
   Stack,
   Table,
   Text,
+  Tooltip,
 } from '@mantine/core'
 
 /**
@@ -23,8 +25,7 @@ import {
  *     original: string,
  *     newValue: string,
  *   }>}
- *   onConfirm    {() => Promise<Map<string, Error|null>>}
- *                resolves with a Map of contactId → Error (null means success)
+ *   onConfirm    {(onProgress: (contactId, status, error?) => void) => Promise<void>}
  *   personOpSummary {edits: number, adds: number, deletes: number}
  */
 export default function CommitModal({
@@ -35,19 +36,37 @@ export default function CommitModal({
   personOpSummary,
 }) {
   const [saving, setSaving] = useState(false)
-  const [errors, setErrors] = useState({}) // { [contactId]: string }
+  // { [contactId]: 'saving' | 'success' | 'error' }
+  const [rowStatus, setRowStatus] = useState({})
+  // { [contactId]: string }
+  const [rowErrors, setRowErrors] = useState({})
 
-  async function handleConfirm() {
+  function handleProgress(contactId, status, error) {
+    setRowStatus((prev) => ({ ...prev, [contactId]: status }))
+    if (status === 'error' && error) {
+      setRowErrors((prev) => ({
+        ...prev,
+        [contactId]: error.message ?? String(error),
+      }))
+    }
+  }
+
+  // Collect errors locally during the call (state updates are async so we can't
+  // reliably read rowErrors right after onConfirm resolves).
+  async function handleConfirmTracked() {
     setSaving(true)
-    setErrors({})
-    try {
-      const resultMap = await onConfirm()
-      const newErrors = {}
-      for (const [contactId, err] of resultMap) {
-        if (err) newErrors[contactId] = err.message ?? String(err)
+    setRowStatus({})
+    setRowErrors({})
+    const localErrors = {}
+    function trackedProgress(contactId, status, error) {
+      handleProgress(contactId, status, error)
+      if (status === 'error' && error) {
+        localErrors[contactId] = error.message ?? String(error)
       }
-      setErrors(newErrors)
-      if (Object.keys(newErrors).length === 0) {
+    }
+    try {
+      await onConfirm(trackedProgress)
+      if (Object.keys(localErrors).length === 0) {
         onClose()
       }
     } finally {
@@ -57,12 +76,12 @@ export default function CommitModal({
 
   function handleClose() {
     if (saving) return
-    setErrors({})
+    setRowStatus({})
+    setRowErrors({})
     onClose()
   }
 
-  // Collect unique contact IDs that have errors
-  const contactIdsWithErrors = new Set(Object.keys(errors))
+  const hasErrors = Object.keys(rowErrors).length > 0
 
   return (
     <Modal
@@ -81,6 +100,7 @@ export default function CommitModal({
         <Table withTableBorder withColumnBorders fz="sm">
           <Table.Thead>
             <Table.Tr>
+              <Table.Th w={32}></Table.Th>
               <Table.Th>Contact</Table.Th>
               <Table.Th>Field</Table.Th>
               <Table.Th>Original</Table.Th>
@@ -88,21 +108,30 @@ export default function CommitModal({
             </Table.Tr>
           </Table.Thead>
           <Table.Tbody>
-            {pendingChanges.map((change, i) => (
-              <Table.Tr
-                key={i}
-                style={
-                  contactIdsWithErrors.has(change.contactId)
-                    ? { backgroundColor: '#fff1f2' }
-                    : undefined
-                }
-              >
-                <Table.Td>{change.contactName}</Table.Td>
-                <Table.Td>{change.field}</Table.Td>
-                <Table.Td c="dimmed">{change.original}</Table.Td>
-                <Table.Td fw={500}>{change.newValue}</Table.Td>
-              </Table.Tr>
-            ))}
+            {pendingChanges.map((change, i) => {
+              const status = rowStatus[change.contactId]
+              const errMsg = rowErrors[change.contactId]
+              return (
+                <Table.Tr
+                  key={i}
+                  style={
+                    status === 'error'
+                      ? { backgroundColor: '#fff1f2' }
+                      : status === 'success'
+                        ? { backgroundColor: '#f0fdf4' }
+                        : undefined
+                  }
+                >
+                  <Table.Td ta="center" py={2}>
+                    <StatusIcon status={status} errorMsg={errMsg} />
+                  </Table.Td>
+                  <Table.Td>{change.contactName}</Table.Td>
+                  <Table.Td>{change.field}</Table.Td>
+                  <Table.Td c="dimmed">{change.original}</Table.Td>
+                  <Table.Td fw={500}>{change.newValue}</Table.Td>
+                </Table.Tr>
+              )
+            })}
           </Table.Tbody>
         </Table>
 
@@ -115,47 +144,80 @@ export default function CommitModal({
             </Text>
             {personOpSummary.edits > 0 && (
               <Text size="sm" c="dimmed">
-                • {personOpSummary.edits} field edit
+                &bull; {personOpSummary.edits} field edit
                 {personOpSummary.edits !== 1 ? 's' : ''}
               </Text>
             )}
             {personOpSummary.adds > 0 && (
               <Text size="sm" c="dimmed">
-                • {personOpSummary.adds} addition
+                &bull; {personOpSummary.adds} addition
                 {personOpSummary.adds !== 1 ? 's' : ''}
               </Text>
             )}
             {personOpSummary.deletes > 0 && (
               <Text size="sm" c="dimmed">
-                • {personOpSummary.deletes} deletion
+                &bull; {personOpSummary.deletes} deletion
                 {personOpSummary.deletes !== 1 ? 's' : ''}
               </Text>
             )}
           </Stack>
         )}
 
-        {Object.entries(errors).map(([contactId, msg]) => {
-          const contact = pendingChanges.find((c) => c.contactId === contactId)
-          return (
-            <Alert
-              key={contactId}
-              color="red"
-              title={`Failed: ${contact?.contactName ?? contactId}`}
-            >
-              {msg}
-            </Alert>
-          )
-        })}
+        {hasErrors && (
+          <Alert color="red" title="Some changes failed to save">
+            Failed rows are highlighted above. Fix the issue or retry — only
+            failed edits remain in the queue.
+          </Alert>
+        )}
 
         <Group justify="flex-end" gap="sm">
           <Button variant="default" onClick={handleClose} disabled={saving}>
-            Cancel
+            {hasErrors ? 'Close' : 'Cancel'}
           </Button>
-          <Button color="orange" onClick={handleConfirm} loading={saving}>
-            Confirm &amp; Save
+          <Button
+            color="orange"
+            onClick={handleConfirmTracked}
+            loading={saving}
+          >
+            {hasErrors ? 'Retry failed' : 'Confirm \u0026 Save'}
           </Button>
         </Group>
       </Stack>
     </Modal>
   )
+}
+
+function StatusIcon({ status, errorMsg }) {
+  if (!status) return null
+  if (status === 'saving') {
+    return <Loader size={14} />
+  }
+  if (status === 'success') {
+    return (
+      <span
+        style={{ color: '#2f9e44', fontWeight: 700, fontSize: 14 }}
+        aria-label="Saved"
+      >
+        ✓
+      </span>
+    )
+  }
+  if (status === 'error') {
+    return (
+      <Tooltip label={errorMsg ?? 'Error'} withArrow>
+        <span
+          style={{
+            color: '#e03131',
+            fontWeight: 700,
+            fontSize: 14,
+            cursor: 'help',
+          }}
+          aria-label="Failed"
+        >
+          ✕
+        </span>
+      </Tooltip>
+    )
+  }
+  return null
 }

--- a/src/components/CustomerTable.jsx
+++ b/src/components/CustomerTable.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react'
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
 import {
   useReactTable,
   getCoreRowModel,
@@ -78,6 +78,40 @@ function writeColTypesCookie(overrides) {
   // 1-year expiry
   const expires = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toUTCString()
   document.cookie = `${COOKIE_NAME}=${value}; expires=${expires}; path=/; SameSite=Lax`
+}
+
+// ---
+
+// --- Edit state persistence ---
+
+function editStateKey(orgId) {
+  return `lions-edit-state-${orgId}`
+}
+
+function loadEditState(orgId) {
+  try {
+    const raw = localStorage.getItem(editStateKey(orgId))
+    if (!raw) return null
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+function saveEditState(orgId, state) {
+  try {
+    localStorage.setItem(editStateKey(orgId), JSON.stringify(state))
+  } catch {
+    // ignore storage errors
+  }
+}
+
+function clearEditState(orgId) {
+  try {
+    localStorage.removeItem(editStateKey(orgId))
+  } catch {
+    // ignore storage errors
+  }
 }
 
 // ---
@@ -206,10 +240,21 @@ export default function CustomerTable() {
   const { mutateAsync: saveContact } = useUpdateContact()
 
   // Edit mode toggle
-  const [isEditMode, setIsEditMode] = useState(false)
+  const [isEditMode, setIsEditMode] = useState(() => {
+    const stored = loadEditState(orgId)
+    return (
+      stored != null &&
+      (Object.keys(stored.dirtyMap ?? {}).length > 0 ||
+        Object.keys(stored.pendingPersonEdits ?? {}).length > 0 ||
+        Object.keys(stored.pendingPersonAdds ?? {}).length > 0 ||
+        Object.keys(stored.pendingPersonDeletes ?? {}).length > 0)
+    )
+  })
 
   // dirtyMap: { [contactId]: { [columnId]: newValue } }
-  const [dirtyMap, setDirtyMap] = useState({})
+  const [dirtyMap, setDirtyMap] = useState(
+    () => loadEditState(orgId)?.dirtyMap ?? {}
+  )
 
   // validationErrors: { [contactId]: { [columnId]: string } }
   const [validationErrors, setValidationErrors] = useState({})
@@ -230,11 +275,48 @@ export default function CustomerTable() {
 
   // Pending contact person mutations — all staged until global Commit
   // { [contactId]: { [personId]: { [field]: newValue } } }
-  const [pendingPersonEdits, setPendingPersonEdits] = useState({})
+  const [pendingPersonEdits, setPendingPersonEdits] = useState(
+    () => loadEditState(orgId)?.pendingPersonEdits ?? {}
+  )
   // { [contactId]: Array<{ _tempId, first_name, last_name, email, phone, mobile }> }
-  const [pendingPersonAdds, setPendingPersonAdds] = useState({})
+  const [pendingPersonAdds, setPendingPersonAdds] = useState(
+    () => loadEditState(orgId)?.pendingPersonAdds ?? {}
+  )
   // { [contactId]: personId[] }
-  const [pendingPersonDeletes, setPendingPersonDeletes] = useState({})
+  const [pendingPersonDeletes, setPendingPersonDeletes] = useState(
+    () => loadEditState(orgId)?.pendingPersonDeletes ?? {}
+  )
+
+  // Persist edit state to localStorage whenever it changes.
+  // Skip the initial render to avoid a redundant write on load.
+  const isFirstRender = useRef(true)
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    const isEmpty =
+      Object.keys(dirtyMap).length === 0 &&
+      Object.keys(pendingPersonEdits).length === 0 &&
+      Object.keys(pendingPersonAdds).length === 0 &&
+      Object.keys(pendingPersonDeletes).length === 0
+    if (isEmpty) {
+      clearEditState(orgId)
+    } else {
+      saveEditState(orgId, {
+        dirtyMap,
+        pendingPersonEdits,
+        pendingPersonAdds,
+        pendingPersonDeletes,
+      })
+    }
+  }, [
+    orgId,
+    dirtyMap,
+    pendingPersonEdits,
+    pendingPersonAdds,
+    pendingPersonDeletes,
+  ])
 
   const markDirty = useCallback((contactId, columnId, value) => {
     setDirtyMap((prev) => ({
@@ -652,36 +734,38 @@ export default function CustomerTable() {
     return changes
   }, [dirtyMap, contacts, columns])
 
-  // Called by CommitModal — saves all dirty contacts and person mutations
-  async function handleCommit() {
-    const entries = Object.entries(dirtyMap)
-    const results = await Promise.allSettled(
-      entries.map(([contactId, dirtyFields]) => {
-        const original = contacts.find((c) => c.contact_id === contactId)
-        if (!original) return Promise.resolve()
-        return saveContact({
+  // Called by CommitModal — saves all dirty contacts and person mutations sequentially.
+  // onProgress(contactId, 'saving' | 'success' | 'error', error?) is called per contact.
+  async function handleCommit(onProgress) {
+    // --- Contact field edits (sequential to avoid rate limiting) ---
+    for (const [contactId, dirtyFields] of Object.entries(dirtyMap)) {
+      const original = contacts.find((c) => c.contact_id === contactId)
+      if (!original) continue
+      onProgress(contactId, 'saving')
+      try {
+        await saveContact({
           contactId,
           payload: buildPayload(original, dirtyFields),
         })
-      })
-    )
+        onProgress(contactId, 'success')
+        setDirtyMap((prev) => {
+          const next = { ...prev }
+          delete next[contactId]
+          return next
+        })
+      } catch (err) {
+        onProgress(contactId, 'error', err)
+        // Leave this contactId in dirtyMap so the user can retry
+      }
+    }
 
-    // Clear only successful saves from dirtyMap
-    setDirtyMap((prev) => {
-      const next = { ...prev }
-      entries.forEach(([contactId], i) => {
-        if (results[i].status === 'fulfilled') delete next[contactId]
-      })
-      return next
-    })
-
-    // Commit pending contact person operations
+    // --- Contact person operations ---
     const affectedContactIds = new Set()
 
     for (const [contactId, persons] of Object.entries(pendingPersonEdits)) {
       const cachedPersons =
         queryClient.getQueryData(['contactPersons', contactId]) ?? []
-      await Promise.allSettled(
+      const results = await Promise.allSettled(
         Object.entries(persons).map(([personId, fields]) => {
           const original = cachedPersons.find(
             (p) => p.contact_person_id === personId
@@ -708,11 +792,23 @@ export default function CustomerTable() {
           )
         })
       )
+      // Remove only the person edits that succeeded
+      const personIds = Object.keys(persons)
+      setPendingPersonEdits((prev) => {
+        const updatedPersons = { ...(prev[contactId] ?? {}) }
+        personIds.forEach((personId, i) => {
+          if (results[i].status === 'fulfilled') delete updatedPersons[personId]
+        })
+        const next = { ...prev }
+        if (Object.keys(updatedPersons).length === 0) delete next[contactId]
+        else next[contactId] = updatedPersons
+        return next
+      })
       affectedContactIds.add(contactId)
     }
 
     for (const [contactId, drafts] of Object.entries(pendingPersonAdds)) {
-      await Promise.allSettled(
+      const results = await Promise.allSettled(
         drafts.map((d) =>
           createContactPerson(accessToken, orgId, region, contactId, {
             first_name: d.first_name,
@@ -723,34 +819,41 @@ export default function CustomerTable() {
           })
         )
       )
+      // Remove only successful adds
+      setPendingPersonAdds((prev) => {
+        const remaining = (prev[contactId] ?? []).filter(
+          (_, i) => results[i].status === 'rejected'
+        )
+        const next = { ...prev }
+        if (remaining.length === 0) delete next[contactId]
+        else next[contactId] = remaining
+        return next
+      })
       affectedContactIds.add(contactId)
     }
 
     for (const [contactId, personIds] of Object.entries(pendingPersonDeletes)) {
-      await Promise.allSettled(
+      const results = await Promise.allSettled(
         personIds.map((personId) =>
           deleteContactPerson(accessToken, orgId, region, contactId, personId)
         )
       )
+      // Remove only successful deletes
+      setPendingPersonDeletes((prev) => {
+        const remaining = personIds.filter(
+          (_, i) => results[i].status === 'rejected'
+        )
+        const next = { ...prev }
+        if (remaining.length === 0) delete next[contactId]
+        else next[contactId] = remaining
+        return next
+      })
       affectedContactIds.add(contactId)
     }
 
     affectedContactIds.forEach((cid) =>
       queryClient.invalidateQueries({ queryKey: ['contactPersons', cid] })
     )
-    setPendingPersonEdits({})
-    setPendingPersonAdds({})
-    setPendingPersonDeletes({})
-
-    // Return a Map of contactId → Error|null for the modal to display
-    const resultMap = new Map()
-    entries.forEach(([contactId], i) => {
-      resultMap.set(
-        contactId,
-        results[i].status === 'rejected' ? results[i].reason : null
-      )
-    })
-    return resultMap
   }
 
   function enterEditMode() {
@@ -779,19 +882,26 @@ export default function CustomerTable() {
     setExpandedRows(new Set())
   }
 
-  function cancelEditMode() {
+  // Exit edit mode, preserving edits in localStorage for later
+  function exitEditMode() {
+    setValidationErrors({})
+    setIsEditMode(false)
+  }
+
+  // Discard all pending edits and exit edit mode
+  function discardEdits() {
     setDirtyMap({})
     setValidationErrors({})
     setPendingPersonEdits({})
     setPendingPersonAdds({})
     setPendingPersonDeletes({})
+    clearEditState(orgId)
     setIsEditMode(false)
   }
 
-  // After CommitModal closes following a successful save, exit edit mode
+  // After CommitModal closes, exit edit mode if all changes were saved
   function handleModalClose() {
     closeModal()
-    // If all changes were saved, exit edit mode
     if (
       Object.keys(dirtyMap).length === 0 &&
       Object.keys(pendingPersonEdits).length === 0 &&
@@ -844,9 +954,30 @@ export default function CustomerTable() {
                   {dirtyCount + personOpCount !== 1 ? 's' : ''}
                 </Badge>
               )}
-              <Button variant="default" size="sm" onClick={cancelEditMode}>
-                Cancel
-              </Button>
+              {dirtyCount + personOpCount > 0 ? (
+                <>
+                  <Button
+                    variant="default"
+                    size="sm"
+                    onClick={exitEditMode}
+                    title="Exit edit mode — edits are saved and will be restored when you return"
+                  >
+                    Save &amp; Exit
+                  </Button>
+                  <Button
+                    variant="default"
+                    size="sm"
+                    color="red"
+                    onClick={discardEdits}
+                  >
+                    Discard
+                  </Button>
+                </>
+              ) : (
+                <Button variant="default" size="sm" onClick={exitEditMode}>
+                  Exit
+                </Button>
+              )}
               <Button
                 size="sm"
                 color="orange"


### PR DESCRIPTION
## Summary

- **Commit progress**: `CommitModal` now shows per-row status icons (spinner → ✓ / ✕) as each contact is saved sequentially; failed rows stay highlighted with a tooltip showing the error message
- **Partial retry**: Contacts are saved one at a time (reducing rate-limit risk); only successfully committed entries are removed from the dirty queue — failed/rate-limited edits remain for retry with a "Retry failed" button
- **Persistent edit storage**: All staged edits (field changes, person edits/adds/deletes) are persisted to `localStorage` keyed by `orgId`, surviving page refresh and exiting edit mode
- **Save & Exit / Discard**: "Cancel" is replaced with "Save & Exit" (preserves edits in storage) and "Discard" (clears the queue); edit mode auto-restores on page load if saved edits exist

## Test plan

- [ ] Open edit mode, make some changes, click "Save & Exit" → refresh page → edit mode should restore with edits intact
- [ ] Open edit mode, make changes, click "Discard" → edits are gone and edit mode exits
- [ ] Commit with a valid Zoho token → rows show spinner then ✓; modal closes on full success
- [ ] Simulate a failed save (e.g. bad token) → failed rows show ✕ with error tooltip; those edits remain in the queue; "Retry failed" button appears
- [ ] Verify person edits/adds/deletes that succeed are cleared; failed ones remain

Closes #55