### PR TITLE
fix: blank cells, csv drag-drop, export, and business contact display

### DIFF
--- a/src/components/CsvImportModal.jsx
+++ b/src/components/CsvImportModal.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useCallback } from 'react'
 import Papa from 'papaparse'
 import {
   Alert,
@@ -38,6 +38,7 @@ export default function CsvImportModal({
   onApply,
 }) {
   const fileInputRef = useRef(null)
+  const [isDragOver, setIsDragOver] = useState(false)
 
   // Step: 'upload' | 'mapping'
   const [step, setStep] = useState('upload')
@@ -88,9 +89,7 @@ export default function CsvImportModal({
     })),
   ]
 
-  function handleFileChange(e) {
-    const file = e.target.files?.[0]
-    if (!file) return
+  const parseFile = useCallback((file) => {
     setParseError(null)
     Papa.parse(file, {
       header: true,
@@ -119,8 +118,38 @@ export default function CsvImportModal({
         setParseError(err.message)
       },
     })
+  }, [])
+
+  function handleFileChange(e) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    parseFile(file)
     // Reset file input so the same file can be re-selected
     e.target.value = ''
+  }
+
+  function handleDragOver(e) {
+    e.preventDefault()
+    setIsDragOver(true)
+  }
+
+  function handleDragLeave(e) {
+    // Only clear if leaving the drop zone entirely (not entering a child element)
+    if (!e.currentTarget.contains(e.relatedTarget)) {
+      setIsDragOver(false)
+    }
+  }
+
+  function handleDrop(e) {
+    e.preventDefault()
+    setIsDragOver(false)
+    const file = e.dataTransfer.files?.[0]
+    if (!file) return
+    if (!file.name.endsWith('.csv') && file.type !== 'text/csv') {
+      setParseError('Please drop a CSV file.')
+      return
+    }
+    parseFile(file)
   }
 
   function handleMappingChange(csvHeader, zohoField) {
@@ -182,10 +211,6 @@ export default function CsvImportModal({
     >
       {step === 'upload' && (
         <Stack gap="md">
-          <Text size="sm" c="dimmed">
-            Upload a CSV file. Headers will be analyzed and mapped to Zoho
-            contact fields automatically where possible.
-          </Text>
           {parseError && (
             <Alert color="red" title="Parse error">
               {parseError}
@@ -198,9 +223,31 @@ export default function CsvImportModal({
             style={{ display: 'none' }}
             onChange={handleFileChange}
           />
-          <Button onClick={() => fileInputRef.current?.click()}>
-            Choose CSV file…
-          </Button>
+          <div
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+            onClick={() => fileInputRef.current?.click()}
+            style={{
+              border: `2px dashed ${isDragOver ? '#228be6' : '#ced4da'}`,
+              borderRadius: 8,
+              padding: '40px 24px',
+              textAlign: 'center',
+              cursor: 'pointer',
+              background: isDragOver ? '#e7f5ff' : undefined,
+              transition: 'border-color 0.15s, background 0.15s',
+            }}
+          >
+            <Text size="sm" fw={500} mb={4}>
+              {isDragOver
+                ? 'Drop CSV file here'
+                : 'Drop a CSV file here, or click to browse'}
+            </Text>
+            <Text size="xs" c="dimmed">
+              Headers will be mapped to Zoho contact fields automatically where
+              possible.
+            </Text>
+          </div>
           <Group justify="flex-end">
             <Button variant="default" onClick={onClose}>
               Cancel

--- a/src/components/CustomerTable.jsx
+++ b/src/components/CustomerTable.jsx
@@ -28,13 +28,15 @@ import CommitModal from './CommitModal.jsx'
 import ContactPersonsPanel from './ContactPersonsPanel.jsx'
 import CsvImportModal from './CsvImportModal.jsx'
 
-// Human-readable labels for billing sub-fields populated via CSV import
-// (these don't have a column definition in the table)
+// Human-readable labels for fields that may appear in dirtyMap but don't have
+// a matching column header (billing sub-fields from CSV import, etc.)
 const EXTRA_FIELD_LABELS = {
   billing_city: 'Billing City',
   billing_state: 'Billing State',
   billing_zip: 'Billing Zip',
   billing_country: 'Billing Country',
+  company_name: 'Company',
+  customer_sub_type: 'Type',
 }
 
 const PAGE_SIZE_OPTIONS = ['10', '25', '50', '100']
@@ -95,11 +97,22 @@ function getStoredPageSize() {
  * Zoho does not support partial updates, so we must send the full object.
  */
 function buildPayload(original, dirtyFields) {
+  const subType =
+    dirtyFields.customer_sub_type ?? original.customer_sub_type ?? 'individual'
   const first = dirtyFields.first_name ?? original.first_name ?? ''
   const last = dirtyFields.last_name ?? original.last_name ?? ''
+  const companyName =
+    dirtyFields.company_name ??
+    original.company_name ??
+    (original.customer_sub_type === 'business' ? original.contact_name : '')
 
   const payload = {
-    contact_name: `${first} ${last}`.trim(),
+    contact_name:
+      subType === 'business'
+        ? companyName || `${first} ${last}`.trim()
+        : `${first} ${last}`.trim(),
+    customer_sub_type: subType,
+    company_name: companyName,
     first_name: first,
     last_name: last,
     email: original.email ?? '',
@@ -111,7 +124,12 @@ function buildPayload(original, dirtyFields) {
   }
 
   for (const [field, value] of Object.entries(dirtyFields)) {
-    if (field === 'first_name' || field === 'last_name') {
+    if (
+      field === 'first_name' ||
+      field === 'last_name' ||
+      field === 'company_name' ||
+      field === 'customer_sub_type'
+    ) {
       // already handled above
     } else if (field === 'address') {
       payload.billing_address.address = value
@@ -136,6 +154,44 @@ function buildPayload(original, dirtyFields) {
   }
 
   return payload
+}
+
+/** Serialize the current page of contacts to a CSV string and trigger download. */
+function exportContactsToCsv(contacts, customFieldColumns, orgName) {
+  const stdHeaders = ['first_name', 'last_name', 'email', 'phone', 'address']
+  const cfHeaders = customFieldColumns.map((c) => c.id)
+  const allHeaders = [...stdHeaders, ...cfHeaders]
+
+  function escape(v) {
+    const s = v == null ? '' : String(v)
+    return `"${s.replace(/"/g, '""')}"`
+  }
+
+  const rows = contacts.map((c) => [
+    escape(c.first_name),
+    escape(c.last_name),
+    escape(c.email),
+    escape(c.phone),
+    escape(c.billing_address?.address),
+    ...cfHeaders.map((id) =>
+      escape(c.custom_fields?.find((f) => f.api_name === id)?.value)
+    ),
+  ])
+
+  const csv = [allHeaders.map(escape), ...rows]
+    .map((r) => r.join(','))
+    .join('\r\n')
+
+  const date = new Date().toISOString().split('T')[0]
+  const safeName = orgName.replace(/[^a-z0-9]/gi, '_')
+  const filename = `customers-${safeName}-${date}.csv`
+
+  const url = URL.createObjectURL(new Blob([csv], { type: 'text/csv' }))
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
 }
 
 /** Small header component that renders the column name + type override badge */
@@ -450,6 +506,13 @@ export default function CustomerTable() {
         },
       },
       {
+        accessorFn: (row) => row.customer_sub_type ?? 'individual',
+        id: 'customer_sub_type',
+        header: 'Type',
+        cell: EditableCell,
+        meta: { defaultType: 'enum', noTypeSelector: true },
+      },
+      {
         accessorKey: 'first_name',
         header: 'First Name',
         cell: EditableCell,
@@ -460,6 +523,15 @@ export default function CustomerTable() {
         header: 'Last Name',
         cell: EditableCell,
         meta: { defaultType: 'text' },
+      },
+      {
+        accessorFn: (row) =>
+          row.company_name ??
+          (row.customer_sub_type === 'business' ? row.contact_name : ''),
+        id: 'company_name',
+        header: 'Company',
+        cell: EditableCell,
+        meta: { defaultType: 'text', noTypeSelector: true },
       },
       {
         accessorKey: 'email',
@@ -748,6 +820,17 @@ export default function CustomerTable() {
                 onClick={openCsvModal}
               >
                 Import from CSV
+              </Button>
+              <Button
+                size="sm"
+                variant="light"
+                color="gray"
+                onClick={() =>
+                  exportContactsToCsv(contacts, customFieldColumns, orgName)
+                }
+                disabled={contacts.length === 0}
+              >
+                Export CSV
               </Button>
             </>
           )}

--- a/src/components/EditableCell.jsx
+++ b/src/components/EditableCell.jsx
@@ -110,12 +110,23 @@ export default function EditableCell({ getValue, row, column, table }) {
           </Anchor>
         )
       }
-      return <Text size="sm">{displayValue}</Text>
+      return (
+        <Text size="sm" c="dimmed">
+          —
+        </Text>
+      )
     }
     if (type === 'boolean') {
       return (
         <Text size="sm">
           {displayValue === true || displayValue === 'true' ? 'Yes' : 'No'}
+        </Text>
+      )
+    }
+    if (!displayValue && displayValue !== 0) {
+      return (
+        <Text size="sm" c="dimmed">
+          —
         </Text>
       )
     }


### PR DESCRIPTION
## Summary

Four issues fixed in one pass:

- **#10** — View mode now shows `—` placeholder for empty cell values instead of blank space (fixes billing address display and all other blank cells)
- **#57** — CSV import upload step now supports native drag-and-drop in addition to the file picker; drop zone highlights on drag-over
- **#6** — Added **Export CSV** button to the toolbar (view mode only); downloads current page as a properly escaped RFC 4180 CSV, filename `customers-{org}-{date}.csv`
- **#43** — Added **Type** column (`individual`/`business` toggle in edit mode) and **Company** column for business contacts; `buildPayload` now correctly constructs `contact_name` and `company_name` for business contacts so saving a business contact no longer wipes the company name

## Files changed

- `src/components/EditableCell.jsx` — `—` placeholder for empty view-mode cells
- `src/components/CsvImportModal.jsx` — drag-and-drop upload zone
- `src/components/CustomerTable.jsx` — export function, Type + Company columns, updated `buildPayload`

## Test plan

- [ ] In view mode, cells with no value show `—` (check billing address, email, phone)
- [ ] Open CSV import modal → drag a .csv file onto the drop zone → proceeds to mapping step
- [ ] Click Export CSV → file downloads with correct headers and org/date in filename
- [ ] In edit mode, Type column shows `individual`/`business` for each contact; changing it marks the row dirty
- [ ] Business contacts show company name in Company column; saving updates Zoho correctly