### PR TITLE
feat: debug mode and improved commit progress UX

### DIFF
--- a/src/components/CommitModal.jsx
+++ b/src/components/CommitModal.jsx
@@ -1,10 +1,11 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import {
   Alert,
   Button,
   Group,
   Loader,
   Modal,
+  Progress,
   ScrollArea,
   Stack,
   Table,
@@ -40,16 +41,22 @@ export default function CommitModal({
   const [rowStatus, setRowStatus] = useState({})
   // { [contactId]: string }
   const [rowErrors, setRowErrors] = useState({})
+  // Ordered log of completed contacts: [{ contactName, status, errorMsg? }]
+  const [logEntries, setLogEntries] = useState([])
 
-  function handleProgress(contactId, status, error) {
-    setRowStatus((prev) => ({ ...prev, [contactId]: status }))
-    if (status === 'error' && error) {
-      setRowErrors((prev) => ({
-        ...prev,
-        [contactId]: error.message ?? String(error),
-      }))
-    }
-  }
+  // Total unique contacts to save (for progress bar)
+  const totalContacts = useMemo(
+    () => new Set(pendingChanges.map((c) => c.contactId)).size,
+    [pendingChanges]
+  )
+
+  const completed = Object.values(rowStatus).filter(
+    (s) => s === 'success' || s === 'error'
+  ).length
+  const progressValue =
+    totalContacts > 0 ? Math.round((completed / totalContacts) * 100) : 0
+  const hasErrors = Object.keys(rowErrors).length > 0
+  const showProgress = saving || completed > 0
 
   // Collect errors locally during the call (state updates are async so we can't
   // reliably read rowErrors right after onConfirm resolves).
@@ -57,13 +64,34 @@ export default function CommitModal({
     setSaving(true)
     setRowStatus({})
     setRowErrors({})
+    setLogEntries([])
     const localErrors = {}
+
     function trackedProgress(contactId, status, error) {
-      handleProgress(contactId, status, error)
+      setRowStatus((prev) => ({ ...prev, [contactId]: status }))
       if (status === 'error' && error) {
-        localErrors[contactId] = error.message ?? String(error)
+        const msg = error.message ?? String(error)
+        setRowErrors((prev) => ({ ...prev, [contactId]: msg }))
+        localErrors[contactId] = msg
+      }
+      if (status === 'success' || status === 'error') {
+        const name =
+          pendingChanges.find((c) => c.contactId === contactId)?.contactName ??
+          contactId
+        setLogEntries((prev) => [
+          ...prev,
+          {
+            contactName: name,
+            status,
+            errorMsg:
+              status === 'error'
+                ? (error?.message ?? String(error))
+                : undefined,
+          },
+        ])
       }
     }
+
     try {
       await onConfirm(trackedProgress)
       if (Object.keys(localErrors).length === 0) {
@@ -78,10 +106,9 @@ export default function CommitModal({
     if (saving) return
     setRowStatus({})
     setRowErrors({})
+    setLogEntries([])
     onClose()
   }
-
-  const hasErrors = Object.keys(rowErrors).length > 0
 
   return (
     <Modal
@@ -92,10 +119,71 @@ export default function CommitModal({
       scrollAreaComponent={ScrollArea.Autosize}
     >
       <Stack gap="md">
-        <Text size="sm" c="dimmed">
-          Review the pending changes below. Click &ldquo;Confirm &amp;
-          Save&rdquo; to write them to Zoho.
-        </Text>
+        {!showProgress && (
+          <Text size="sm" c="dimmed">
+            Review the pending changes below. Click &ldquo;Confirm &amp;
+            Save&rdquo; to write them to Zoho.
+          </Text>
+        )}
+
+        {showProgress && (
+          <Stack gap={6}>
+            <Group justify="space-between">
+              <Text size="sm" fw={500}>
+                {saving
+                  ? 'Saving…'
+                  : hasErrors
+                    ? 'Completed with errors'
+                    : 'All changes saved'}
+              </Text>
+              <Text size="sm" c="dimmed">
+                {completed} / {totalContacts}
+              </Text>
+            </Group>
+            <Progress
+              value={progressValue}
+              color={saving ? 'orange' : hasErrors ? 'red' : 'green'}
+              animated={saving}
+              size="sm"
+            />
+          </Stack>
+        )}
+
+        {logEntries.length > 0 && (
+          <Stack gap={2}>
+            {logEntries.map((entry, i) => (
+              <Group key={i} gap={6} align="center">
+                <span
+                  style={{
+                    fontSize: 13,
+                    fontWeight: 700,
+                    color: entry.status === 'success' ? '#2f9e44' : '#e03131',
+                    flexShrink: 0,
+                  }}
+                >
+                  {entry.status === 'success' ? '✓' : '✕'}
+                </span>
+                <Text size="sm">
+                  {entry.contactName}
+                  {entry.errorMsg && (
+                    <Text span c="red" size="sm">
+                      {' '}
+                      — {entry.errorMsg}
+                    </Text>
+                  )}
+                </Text>
+              </Group>
+            ))}
+            {saving && (
+              <Group gap={6} align="center">
+                <Loader size={12} />
+                <Text size="sm" c="dimmed">
+                  Saving…
+                </Text>
+              </Group>
+            )}
+          </Stack>
+        )}
 
         <Table withTableBorder withColumnBorders fz="sm">
           <Table.Thead>

--- a/src/components/CustomerTable.jsx
+++ b/src/components/CustomerTable.jsx
@@ -28,6 +28,7 @@ import EditableCell from './EditableCell.jsx'
 import CommitModal from './CommitModal.jsx'
 import ContactPersonsPanel from './ContactPersonsPanel.jsx'
 import CsvImportModal from './CsvImportModal.jsx'
+import { debugLog } from '../lib/debug.js'
 
 // Human-readable labels for fields that may appear in dirtyMap but don't have
 // a matching column header (billing sub-fields from CSV import, etc.)
@@ -813,12 +814,19 @@ export default function CustomerTable() {
     for (const [contactId, dirtyFields] of Object.entries(dirtyMap)) {
       const original = contacts.find((c) => c.contact_id === contactId)
       if (!original) continue
+      debugLog(
+        `commit: saving contact ${original.contact_name} (${contactId})`,
+        dirtyFields
+      )
       onProgress(contactId, 'saving')
       try {
         await saveContact({
           contactId,
           payload: buildPayload(original, dirtyFields),
         })
+        debugLog(
+          `commit: saved contact ${original.contact_name} (${contactId})`
+        )
         onProgress(contactId, 'success')
         setDirtyMap((prev) => {
           const next = { ...prev }
@@ -826,6 +834,10 @@ export default function CustomerTable() {
           return next
         })
       } catch (err) {
+        debugLog(
+          `commit: failed contact ${original.contact_name} (${contactId})`,
+          err
+        )
         onProgress(contactId, 'error', err)
         // Leave this contactId in dirtyMap so the user can retry
       }

--- a/src/lib/csvImport.js
+++ b/src/lib/csvImport.js
@@ -1,6 +1,7 @@
 /**
  * CSV import utilities — pure functions, no React dependencies.
  */
+import { debugLog } from './debug.js'
 
 /** Standard Zoho contact fields available as mapping targets. */
 export const STANDARD_ZOHO_FIELDS = [
@@ -172,6 +173,13 @@ export function applyMapping(
       const csvValue = normalizeWs(row[csvHeader])
       const currentValue = normalizeWs(getContactFieldValue(contact, zohoField))
       if (csvValue !== currentValue) {
+        debugLog(
+          `csv-diff contact=${contact.contact_name} field=${zohoField}`,
+          '\n  csv: ',
+          JSON.stringify(csvValue),
+          '\n  zoho:',
+          JSON.stringify(currentValue)
+        )
         fields[zohoField] = csvValue
       }
     }
@@ -181,5 +189,9 @@ export function applyMapping(
     }
   }
 
+  debugLog(
+    `csv-import summary: matched=${matchedCount} unmatched=${unmatchedCount}`,
+    `contacts with changes=${Object.keys(dirtyMap).length}`
+  )
   return { dirtyMap, matchedCount, unmatchedCount }
 }

--- a/src/lib/debug.js
+++ b/src/lib/debug.js
@@ -1,0 +1,49 @@
+/**
+ * Debug mode utilities.
+ *
+ * Toggle from the browser console:
+ *   window.lionsDebug(true)   // enable
+ *   window.lionsDebug(false)  // disable
+ *
+ * Persisted in localStorage so it survives refresh.
+ */
+
+const STORAGE_KEY = 'lionsDebug'
+
+export function isDebugEnabled() {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+export function debugLog(...args) {
+  if (isDebugEnabled()) {
+    console.debug('[lions]', ...args)
+  }
+}
+
+// Expose toggle on window at module load time
+if (typeof window !== 'undefined') {
+  window.lionsDebug = (enabled) => {
+    try {
+      if (enabled) {
+        localStorage.setItem(STORAGE_KEY, 'true')
+        console.info(
+          '[lions] Debug mode enabled. Call window.lionsDebug(false) to disable.'
+        )
+      } else {
+        localStorage.removeItem(STORAGE_KEY)
+        console.info('[lions] Debug mode disabled.')
+      }
+    } catch {
+      console.error('[lions] Could not persist debug mode setting.')
+    }
+  }
+  if (isDebugEnabled()) {
+    console.info(
+      '[lions] Debug mode is ON. Call window.lionsDebug(false) to disable.'
+    )
+  }
+}


### PR DESCRIPTION
## Summary

### Debug mode (Closes #61)
- New `src/lib/debug.js` — `isDebugEnabled()` / `debugLog()` with no-op when disabled; `window.lionsDebug(true/false)` toggle persisted to `localStorage`; logs a banner on page load if debug is on
- **CSV import**: logs each field diff with `JSON.stringify` values (makes invisible chars visible) and a post-apply summary
- **Commit**: logs each contact save attempt, success, and failure with field diff details

### Commit progress UX (Closes #55)
- Animated **progress bar** (orange while saving → green on full success / red if any fail) with `X / total` counter
- **Live activity log** that builds up as each contact completes: `✓ John Smith` or `✕ Jane Doe — <error>`, so you can see what's happening without scrolling the changes table
- Per-row status icons (spinner / ✓ / ✕) remain in the changes table

## Test plan
- [ ] Open browser console, run `window.lionsDebug(true)`, then do a CSV import — should see `[lions] csv-diff ...` lines with exact string values
- [ ] Run `window.lionsDebug(false)` — no more debug output
- [ ] Debug mode survives page refresh (check `localStorage.lionsDebug`)
- [ ] Commit changes — progress bar animates as each contact is saved, activity log populates live
- [ ] Simulate a failure (revoke token) — failed contacts show in red in the log and remain in the queue