### PR TITLE
feat: contact detail panel, minimized columns, CSV derived rules, and grouped commit modal

### DIFF
--- a/src/components/CommitModal.jsx
+++ b/src/components/CommitModal.jsx
@@ -1,20 +1,29 @@
 import { useMemo, useState } from 'react'
 import {
   Alert,
+  Box,
   Button,
   Group,
   Loader,
   Modal,
+  Paper,
   Progress,
   ScrollArea,
   Stack,
-  Table,
   Text,
   Tooltip,
 } from '@mantine/core'
 
+const ADDRESS_FIELDS = new Set([
+  'address',
+  'billing_city',
+  'billing_state',
+  'billing_zip',
+  'billing_country',
+])
+
 /**
- * CommitModal — lists all pending changes and confirms save.
+ * CommitModal — lists all pending changes grouped per contact and confirms save.
  *
  * Props:
  *   opened       {boolean}
@@ -22,6 +31,7 @@ import {
  *   pendingChanges {Array<{
  *     contactId: string,
  *     contactName: string,
+ *     fieldId: string,
  *     field: string,
  *     original: string,
  *     newValue: string,
@@ -44,11 +54,24 @@ export default function CommitModal({
   // Ordered log of completed contacts: [{ contactName, status, errorMsg? }]
   const [logEntries, setLogEntries] = useState([])
 
+  // Group pendingChanges by contactId
+  const grouped = useMemo(() => {
+    const map = new Map()
+    for (const change of pendingChanges) {
+      if (!map.has(change.contactId)) {
+        map.set(change.contactId, {
+          contactId: change.contactId,
+          contactName: change.contactName,
+          fields: [],
+        })
+      }
+      map.get(change.contactId).fields.push(change)
+    }
+    return Array.from(map.values())
+  }, [pendingChanges])
+
   // Total unique contacts to save (for progress bar)
-  const totalContacts = useMemo(
-    () => new Set(pendingChanges.map((c) => c.contactId)).size,
-    [pendingChanges]
-  )
+  const totalContacts = grouped.length
 
   const completed = Object.values(rowStatus).filter(
     (s) => s === 'success' || s === 'error'
@@ -185,43 +208,65 @@ export default function CommitModal({
           </Stack>
         )}
 
-        <Table withTableBorder withColumnBorders fz="sm">
-          <Table.Thead>
-            <Table.Tr>
-              <Table.Th w={32}></Table.Th>
-              <Table.Th>Contact</Table.Th>
-              <Table.Th>Field</Table.Th>
-              <Table.Th>Original</Table.Th>
-              <Table.Th>New value</Table.Th>
-            </Table.Tr>
-          </Table.Thead>
-          <Table.Tbody>
-            {pendingChanges.map((change, i) => {
-              const status = rowStatus[change.contactId]
-              const errMsg = rowErrors[change.contactId]
-              return (
-                <Table.Tr
-                  key={i}
-                  style={
-                    status === 'error'
-                      ? { backgroundColor: '#fff1f2' }
-                      : status === 'success'
-                        ? { backgroundColor: '#f0fdf4' }
-                        : undefined
+        {/* Per-contact change cards */}
+        <Stack gap="sm">
+          {grouped.map(({ contactId, contactName, fields }) => {
+            const status = rowStatus[contactId]
+            const errMsg = rowErrors[contactId]
+            const addressFields = fields.filter((f) =>
+              ADDRESS_FIELDS.has(f.fieldId)
+            )
+            const otherFields = fields.filter(
+              (f) => !ADDRESS_FIELDS.has(f.fieldId)
+            )
+            return (
+              <Paper
+                key={contactId}
+                withBorder
+                p="sm"
+                style={
+                  status === 'error'
+                    ? { borderColor: '#e03131', backgroundColor: '#fff1f2' }
+                    : status === 'success'
+                      ? { borderColor: '#2f9e44', backgroundColor: '#f0fdf4' }
+                      : undefined
+                }
+              >
+                {/* Card header: contact name + status icon */}
+                <Group
+                  justify="space-between"
+                  mb={
+                    otherFields.length > 0 || addressFields.length > 0 ? 6 : 0
                   }
                 >
-                  <Table.Td ta="center" py={2}>
-                    <StatusIcon status={status} errorMsg={errMsg} />
-                  </Table.Td>
-                  <Table.Td>{change.contactName}</Table.Td>
-                  <Table.Td>{change.field}</Table.Td>
-                  <Table.Td c="dimmed">{change.original}</Table.Td>
-                  <Table.Td fw={500}>{change.newValue}</Table.Td>
-                </Table.Tr>
-              )
-            })}
-          </Table.Tbody>
-        </Table>
+                  <Text size="sm" fw={600}>
+                    {contactName}
+                  </Text>
+                  <StatusIcon status={status} errorMsg={errMsg} />
+                </Group>
+
+                {/* Non-address fields */}
+                {otherFields.map((change) => (
+                  <FieldRow key={change.fieldId} change={change} />
+                ))}
+
+                {/* Address fields grouped */}
+                {addressFields.length > 0 && (
+                  <Box mt={otherFields.length > 0 ? 4 : 0}>
+                    <Text size="xs" fw={600} c="dimmed" mb={2}>
+                      Billing Address
+                    </Text>
+                    <Box pl="md">
+                      {addressFields.map((change) => (
+                        <FieldRow key={change.fieldId} change={change} />
+                      ))}
+                    </Box>
+                  </Box>
+                )}
+              </Paper>
+            )
+          })}
+        </Stack>
 
         {(personOpSummary?.edits > 0 ||
           personOpSummary?.adds > 0 ||
@@ -253,7 +298,7 @@ export default function CommitModal({
 
         {hasErrors && (
           <Alert color="red" title="Some changes failed to save">
-            Failed rows are highlighted above. Fix the issue or retry — only
+            Failed contacts are highlighted above. Fix the issue or retry — only
             failed edits remain in the queue.
           </Alert>
         )}
@@ -272,6 +317,55 @@ export default function CommitModal({
         </Group>
       </Stack>
     </Modal>
+  )
+}
+
+function FieldRow({ change }) {
+  return (
+    <Group gap={8} py={1} wrap="nowrap">
+      <Text size="xs" c="dimmed" style={{ minWidth: 100, flexShrink: 0 }}>
+        {change.field}
+      </Text>
+      {change.original ? (
+        <>
+          <Text
+            size="xs"
+            c="dimmed"
+            style={{
+              maxWidth: 180,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {change.original}
+          </Text>
+          <Text size="xs" c="dimmed">
+            →
+          </Text>
+        </>
+      ) : (
+        <Text size="xs" c="dimmed">
+          →
+        </Text>
+      )}
+      <Text
+        size="xs"
+        fw={500}
+        style={{
+          maxWidth: 220,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {change.newValue || (
+          <Text span c="dimmed" fs="italic">
+            empty
+          </Text>
+        )}
+      </Text>
+    </Group>
   )
 }
 

--- a/src/components/ContactDetailPanel.jsx
+++ b/src/components/ContactDetailPanel.jsx
@@ -1,0 +1,222 @@
+import { Grid, Stack, Text } from '@mantine/core'
+import EditableCell from './EditableCell.jsx'
+import { getContactFieldValue } from '../lib/csvImport.js'
+
+/** Render a labeled field using EditableCell's fake-context pattern. */
+function FieldCell({ label, fieldId, contact, defaultType, meta }) {
+  return (
+    <Stack gap={2}>
+      <Text size="xs" fw={500} c="dimmed">
+        {label}
+      </Text>
+      <EditableCell
+        getValue={() => getContactFieldValue(contact, fieldId)}
+        row={{ original: contact }}
+        column={{ id: fieldId, columnDef: { meta: { defaultType } } }}
+        table={{ options: { meta } }}
+      />
+    </Stack>
+  )
+}
+
+function SectionHeading({ children }) {
+  return (
+    <Text
+      size="xs"
+      fw={700}
+      tt="uppercase"
+      c="dimmed"
+      style={{
+        letterSpacing: '0.05em',
+        borderBottom: '1px solid #e9ecef',
+        paddingBottom: 4,
+      }}
+    >
+      {children}
+    </Text>
+  )
+}
+
+/**
+ * ContactDetailPanel — grouped form showing all editable contact fields.
+ *
+ * Displayed in the expanded row below the table row, above ContactPersonsPanel.
+ *
+ * Props passed through to EditableCell via fake table meta:
+ *   isEditMode, isDirty, getDirtyValue, markDirty, clearDirty,
+ *   setValidationError, clearValidationError, getColType, getEnumValues
+ */
+export default function ContactDetailPanel({
+  contact,
+  isEditMode,
+  isDirty,
+  getDirtyValue,
+  markDirty,
+  clearDirty,
+  setValidationError,
+  clearValidationError,
+  getColType,
+  getEnumValues,
+}) {
+  const meta = {
+    isEditMode,
+    isDirty,
+    getDirtyValue,
+    markDirty,
+    clearDirty,
+    setValidationError,
+    clearValidationError,
+    getColType,
+    getEnumValues,
+  }
+
+  const customFields = contact.custom_fields ?? []
+
+  /** Resolve defaultType for a custom field */
+  function cfDefaultType(cf) {
+    if (cf.data_type === 'dropdown') return 'enum'
+    return 'text'
+  }
+
+  return (
+    <Stack gap="sm" p="md" style={{ borderBottom: '1px solid #e9ecef' }}>
+      {/* Basic Info */}
+      <SectionHeading>Basic Info</SectionHeading>
+      <Grid gutter="sm">
+        <Grid.Col span={{ base: 12, xs: 6 }}>
+          <FieldCell
+            label="Type"
+            fieldId="customer_sub_type"
+            contact={contact}
+            defaultType="enum"
+            meta={meta}
+          />
+        </Grid.Col>
+        <Grid.Col span={{ base: 12, xs: 6 }}>
+          <FieldCell
+            label="Company"
+            fieldId="company_name"
+            contact={contact}
+            defaultType="text"
+            meta={meta}
+          />
+        </Grid.Col>
+        <Grid.Col span={{ base: 12, xs: 6 }}>
+          <FieldCell
+            label="First Name"
+            fieldId="first_name"
+            contact={contact}
+            defaultType="text"
+            meta={meta}
+          />
+        </Grid.Col>
+        <Grid.Col span={{ base: 12, xs: 6 }}>
+          <FieldCell
+            label="Last Name"
+            fieldId="last_name"
+            contact={contact}
+            defaultType="text"
+            meta={meta}
+          />
+        </Grid.Col>
+        <Grid.Col span={{ base: 12, xs: 6 }}>
+          <FieldCell
+            label="Email"
+            fieldId="email"
+            contact={contact}
+            defaultType="email"
+            meta={meta}
+          />
+        </Grid.Col>
+        <Grid.Col span={{ base: 12, xs: 6 }}>
+          <FieldCell
+            label="Mobile"
+            fieldId="mobile"
+            contact={contact}
+            defaultType="phone"
+            meta={meta}
+          />
+        </Grid.Col>
+        <Grid.Col span={{ base: 12, xs: 6 }}>
+          <FieldCell
+            label="Phone"
+            fieldId="phone"
+            contact={contact}
+            defaultType="phone"
+            meta={meta}
+          />
+        </Grid.Col>
+      </Grid>
+
+      {/* Billing Address */}
+      <SectionHeading>Billing Address</SectionHeading>
+      <Grid gutter="sm">
+        <Grid.Col span={12}>
+          <FieldCell
+            label="Street"
+            fieldId="address"
+            contact={contact}
+            defaultType="text"
+            meta={meta}
+          />
+        </Grid.Col>
+        <Grid.Col span={{ base: 12, xs: 6 }}>
+          <FieldCell
+            label="City"
+            fieldId="billing_city"
+            contact={contact}
+            defaultType="text"
+            meta={meta}
+          />
+        </Grid.Col>
+        <Grid.Col span={{ base: 12, xs: 6 }}>
+          <FieldCell
+            label="State"
+            fieldId="billing_state"
+            contact={contact}
+            defaultType="text"
+            meta={meta}
+          />
+        </Grid.Col>
+        <Grid.Col span={{ base: 12, xs: 6 }}>
+          <FieldCell
+            label="Zip / Postal Code"
+            fieldId="billing_zip"
+            contact={contact}
+            defaultType="text"
+            meta={meta}
+          />
+        </Grid.Col>
+        <Grid.Col span={{ base: 12, xs: 6 }}>
+          <FieldCell
+            label="Country"
+            fieldId="billing_country"
+            contact={contact}
+            defaultType="text"
+            meta={meta}
+          />
+        </Grid.Col>
+      </Grid>
+
+      {/* Member Info (custom fields) */}
+      {customFields.length > 0 && (
+        <>
+          <SectionHeading>Member Info</SectionHeading>
+          <Grid gutter="sm">
+            {customFields.map((cf) => (
+              <Grid.Col key={cf.api_name} span={{ base: 12, xs: 6 }}>
+                <FieldCell
+                  label={cf.label ?? cf.api_name}
+                  fieldId={cf.api_name}
+                  contact={contact}
+                  defaultType={cfDefaultType(cf)}
+                  meta={meta}
+                />
+              </Grid.Col>
+            ))}
+          </Grid>
+        </>
+      )}
+    </Stack>
+  )
+}

--- a/src/components/CsvImportModal.jsx
+++ b/src/components/CsvImportModal.jsx
@@ -1,21 +1,28 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import Papa from 'papaparse'
 import {
+  ActionIcon,
   Alert,
   Button,
+  Checkbox,
   Group,
   Modal,
+  Paper,
   ScrollArea,
   Select,
   Stack,
   Table,
   Text,
+  TextInput,
 } from '@mantine/core'
 import {
   STANDARD_ZOHO_FIELDS,
   applyMapping,
+  initialDerivedRules,
   initialMapping,
+  loadSavedDerivedRules,
   loadSavedMatchKey,
+  saveDerivedRules,
   saveMapping,
   saveMatchKey,
 } from '../lib/csvImport.js'
@@ -55,6 +62,11 @@ export default function CsvImportModal({
   const [matchCsvHeader, setMatchCsvHeader] = useState(null)
   const [matchZohoField, setMatchZohoField] = useState(null)
 
+  // Derived field rules: [{ target, parts: [{ csvHeader, prefix }], skipEmpty }]
+  const [derivedRules, setDerivedRules] = useState(
+    () => loadSavedDerivedRules() ?? []
+  )
+
   // Result after applying
   const [applyResult, setApplyResult] = useState(null) // { matchedCount, unmatchedCount }
 
@@ -66,6 +78,7 @@ export default function CsvImportModal({
       setCsvRows([])
       setParseError(null)
       setMapping({})
+      setDerivedRules(loadSavedDerivedRules() ?? [])
       setApplyResult(null)
       // Restore saved match key
       const saved = loadSavedMatchKey()
@@ -89,36 +102,45 @@ export default function CsvImportModal({
     })),
   ]
 
-  const parseFile = useCallback((file) => {
-    setParseError(null)
-    Papa.parse(file, {
-      header: true,
-      skipEmptyLines: true,
-      complete: (result) => {
-        if (result.errors.length > 0 && result.data.length === 0) {
-          setParseError(result.errors[0].message)
-          return
-        }
-        const headers = result.meta.fields ?? []
-        setCsvHeaders(headers)
-        setCsvRows(result.data)
-        const m = initialMapping(headers)
-        setMapping(m)
+  const parseFile = useCallback(
+    (file) => {
+      setParseError(null)
+      Papa.parse(file, {
+        header: true,
+        skipEmptyLines: true,
+        complete: (result) => {
+          if (result.errors.length > 0 && result.data.length === 0) {
+            setParseError(result.errors[0].message)
+            return
+          }
+          const headers = result.meta.fields ?? []
+          setCsvHeaders(headers)
+          setCsvRows(result.data)
+          setMapping(initialMapping(headers, customFields))
 
-        // Auto-select match key if saved one is present in this file's headers
-        const saved = loadSavedMatchKey()
-        if (saved && headers.includes(saved.csvHeader)) {
-          setMatchCsvHeader(saved.csvHeader)
-          setMatchZohoField(saved.zohoField)
-        }
+          // Merge auto-detected derived rules with any saved rules
+          setDerivedRules((prev) => {
+            const auto = initialDerivedRules(headers)
+            const savedTargets = new Set(prev.map((r) => r.target))
+            return [...prev, ...auto.filter((r) => !savedTargets.has(r.target))]
+          })
 
-        setStep('mapping')
-      },
-      error: (err) => {
-        setParseError(err.message)
-      },
-    })
-  }, [])
+          // Auto-select match key if saved one is present in this file's headers
+          const saved = loadSavedMatchKey()
+          if (saved && headers.includes(saved.csvHeader)) {
+            setMatchCsvHeader(saved.csvHeader)
+            setMatchZohoField(saved.zohoField)
+          }
+
+          setStep('mapping')
+        },
+        error: (err) => {
+          setParseError(err.message)
+        },
+      })
+    },
+    [customFields]
+  )
 
   function handleFileChange(e) {
     const file = e.target.files?.[0]
@@ -170,13 +192,15 @@ export default function CsvImportModal({
 
     saveMapping(mapping)
     saveMatchKey(matchCsvHeader, matchZohoField)
+    saveDerivedRules(derivedRules)
 
     const { dirtyMap, matchedCount, unmatchedCount } = applyMapping(
       csvRows,
       mapping,
       matchCsvHeader,
       matchZohoField,
-      contacts
+      contacts,
+      derivedRules
     )
 
     setApplyResult({ matchedCount, unmatchedCount })
@@ -188,6 +212,70 @@ export default function CsvImportModal({
 
     onApply(dirtyMap)
     onClose()
+  }
+
+  // --- Derived rules helpers ---
+
+  function addRule() {
+    setDerivedRules((prev) => [
+      ...prev,
+      {
+        target: '',
+        parts: [{ csvHeader: '', prefix: '' }],
+        skipEmpty: true,
+      },
+    ])
+  }
+
+  function removeRule(idx) {
+    setDerivedRules((prev) => prev.filter((_, i) => i !== idx))
+  }
+
+  function updateRuleTarget(idx, target) {
+    setDerivedRules((prev) =>
+      prev.map((r, i) => (i === idx ? { ...r, target } : r))
+    )
+  }
+
+  function updateRuleSkipEmpty(idx, skipEmpty) {
+    setDerivedRules((prev) =>
+      prev.map((r, i) => (i === idx ? { ...r, skipEmpty } : r))
+    )
+  }
+
+  function addRulePart(idx) {
+    setDerivedRules((prev) =>
+      prev.map((r, i) =>
+        i === idx
+          ? { ...r, parts: [...r.parts, { csvHeader: '', prefix: ' ' }] }
+          : r
+      )
+    )
+  }
+
+  function removeRulePart(ruleIdx, partIdx) {
+    setDerivedRules((prev) =>
+      prev.map((r, i) =>
+        i === ruleIdx
+          ? { ...r, parts: r.parts.filter((_, pi) => pi !== partIdx) }
+          : r
+      )
+    )
+  }
+
+  function updateRulePartField(ruleIdx, partIdx, field, value) {
+    setDerivedRules((prev) =>
+      prev.map((r, i) =>
+        i === ruleIdx
+          ? {
+              ...r,
+              parts: r.parts.map((p, pi) =>
+                pi === partIdx ? { ...p, [field]: value } : p
+              ),
+            }
+          : r
+      )
+    )
   }
 
   // Example value for a CSV header (first non-empty row)
@@ -294,6 +382,126 @@ export default function CsvImportModal({
                 searchable
               />
             </Group>
+          </Stack>
+
+          {/* Derived field rules */}
+          <Stack gap={4}>
+            <Text size="sm" fw={600}>
+              Derived field rules
+            </Text>
+            <Text size="xs" c="dimmed">
+              Combine multiple CSV columns into one Zoho field (e.g. Last Name +
+              Suffix).
+            </Text>
+            {derivedRules.map((rule, ruleIdx) => (
+              <Paper key={ruleIdx} withBorder p="xs">
+                <Stack gap="xs">
+                  <Group gap="xs" align="flex-end" wrap="wrap">
+                    <Select
+                      label="Zoho field"
+                      size="xs"
+                      w={160}
+                      value={rule.target || null}
+                      onChange={(val) => val && updateRuleTarget(ruleIdx, val)}
+                      data={zohoFieldOptions.filter(
+                        (o) => o.value !== '__ignore__'
+                      )}
+                      placeholder="Select…"
+                      searchable
+                      allowDeselect={false}
+                    />
+                    <Text size="xs" pb={6}>
+                      ←
+                    </Text>
+                    {rule.parts.map((part, partIdx) => (
+                      <Group key={partIdx} gap={4} align="flex-end">
+                        {partIdx > 0 && (
+                          <TextInput
+                            label="Prefix"
+                            size="xs"
+                            w={60}
+                            value={part.prefix}
+                            onChange={(e) =>
+                              updateRulePartField(
+                                ruleIdx,
+                                partIdx,
+                                'prefix',
+                                e.target.value
+                              )
+                            }
+                          />
+                        )}
+                        <Select
+                          label={
+                            partIdx === 0 ? 'Primary source' : 'Additional'
+                          }
+                          size="xs"
+                          w={220}
+                          value={part.csvHeader || null}
+                          onChange={(val) =>
+                            val &&
+                            updateRulePartField(
+                              ruleIdx,
+                              partIdx,
+                              'csvHeader',
+                              val
+                            )
+                          }
+                          data={csvHeaders}
+                          placeholder="Select column…"
+                          searchable
+                          allowDeselect={false}
+                          comboboxProps={{ withinPortal: true }}
+                        />
+                        {partIdx > 0 && (
+                          <ActionIcon
+                            size="sm"
+                            variant="subtle"
+                            color="red"
+                            onClick={() => removeRulePart(ruleIdx, partIdx)}
+                          >
+                            ×
+                          </ActionIcon>
+                        )}
+                      </Group>
+                    ))}
+                    <ActionIcon
+                      size="sm"
+                      variant="subtle"
+                      title="Add source column"
+                      onClick={() => addRulePart(ruleIdx)}
+                    >
+                      +
+                    </ActionIcon>
+                    <ActionIcon
+                      size="sm"
+                      variant="subtle"
+                      color="red"
+                      title="Remove rule"
+                      onClick={() => removeRule(ruleIdx)}
+                    >
+                      ×
+                    </ActionIcon>
+                  </Group>
+                  <Checkbox
+                    size="xs"
+                    label="Skip additional parts when empty"
+                    checked={rule.skipEmpty}
+                    onChange={(e) =>
+                      updateRuleSkipEmpty(ruleIdx, e.currentTarget.checked)
+                    }
+                  />
+                </Stack>
+              </Paper>
+            ))}
+            <Button
+              size="xs"
+              variant="subtle"
+              style={{ alignSelf: 'flex-start' }}
+              onClick={addRule}
+            >
+              + Add rule
+            </Button>
           </Stack>
 
           {/* Column mapping table */}

--- a/src/components/CustomerTable.jsx
+++ b/src/components/CustomerTable.jsx
@@ -31,17 +31,20 @@ import EditableCell from './EditableCell.jsx'
 import ColumnHeader from './ColumnHeader.jsx'
 import CommitModal from './CommitModal.jsx'
 import ContactPersonsPanel from './ContactPersonsPanel.jsx'
+import ContactDetailPanel from './ContactDetailPanel.jsx'
 import CsvImportModal from './CsvImportModal.jsx'
 
 // Human-readable labels for fields that may appear in dirtyMap but don't have
-// a matching column header (billing sub-fields from CSV import, etc.)
+// a matching column header (detail panel fields, billing sub-fields from CSV, etc.)
 const EXTRA_FIELD_LABELS = {
+  mobile: 'Mobile',
+  company_name: 'Company',
+  customer_sub_type: 'Type',
+  address: 'Billing Street',
   billing_city: 'Billing City',
   billing_state: 'Billing State',
   billing_zip: 'Billing Zip',
   billing_country: 'Billing Country',
-  company_name: 'Company',
-  customer_sub_type: 'Type',
 }
 
 const PAGE_SIZE_OPTIONS = ['10', '25', '50', '100']
@@ -102,17 +105,20 @@ function buildPayload(original, dirtyFields) {
     original.company_name ??
     (original.customer_sub_type === 'business' ? original.contact_name : '')
 
+  const computedName =
+    subType === 'business'
+      ? companyName || `${first} ${last}`.trim()
+      : `${first} ${last}`.trim()
+
   const payload = {
-    contact_name:
-      subType === 'business'
-        ? companyName || `${first} ${last}`.trim()
-        : `${first} ${last}`.trim(),
+    contact_name: computedName || original.contact_name || '',
     customer_sub_type: subType,
     company_name: companyName,
     first_name: first,
     last_name: last,
-    email: original.email ?? '',
-    phone: original.phone ?? '',
+    email: dirtyFields.email ?? original.email ?? '',
+    phone: dirtyFields.phone ?? original.phone ?? '',
+    mobile: dirtyFields.mobile ?? original.mobile ?? '',
     billing_address: {
       ...(original.billing_address ?? {}),
     },
@@ -254,11 +260,15 @@ export default function CustomerTable() {
   const contacts = data?.contacts ?? []
   const pageContext = data?.page_context ?? {}
 
-  // Build columns dynamically, adding any custom fields from the first contact
-  const customFieldColumns = useMemo(() => {
+  // Build custom field columns dynamically from the first contact.
+  // cf_member_id and cf_member_type are placed at specific table positions;
+  // all other custom fields come after phone.
+  const { pinnedCustomCols, otherCustomCols } = useMemo(() => {
     const first = contacts[0]
-    if (!first?.custom_fields) return []
-    return first.custom_fields.map((cf) => ({
+    if (!first?.custom_fields)
+      return { pinnedCustomCols: [], otherCustomCols: [] }
+    const PINNED = ['cf_member_id', 'cf_member_type']
+    const all = first.custom_fields.map((cf) => ({
       accessorFn: (row) =>
         row.custom_fields?.find((f) => f.api_name === cf.api_name)?.value ?? '',
       id: cf.api_name,
@@ -266,7 +276,17 @@ export default function CustomerTable() {
       cell: EditableCell,
       meta: { defaultType: defaultTypeForCustomField(cf) },
     }))
+    return {
+      pinnedCustomCols: all.filter((c) => PINNED.includes(c.id)),
+      otherCustomCols: all.filter((c) => !PINNED.includes(c.id)),
+    }
   }, [contacts])
+
+  // Combined for legacy references (CSV export etc.)
+  const customFieldColumns = useMemo(
+    () => [...pinnedCustomCols, ...otherCustomCols],
+    [pinnedCustomCols, otherCustomCols]
+  )
 
   /** Resolve effective type for a column (override wins over default) */
   const getColType = useCallback(
@@ -348,13 +368,6 @@ export default function CustomerTable() {
         },
       },
       {
-        accessorFn: (row) => row.customer_sub_type ?? 'individual',
-        id: 'customer_sub_type',
-        header: 'Type',
-        cell: EditableCell,
-        meta: { defaultType: 'enum', noTypeSelector: true },
-      },
-      {
         accessorKey: 'first_name',
         header: 'First Name',
         cell: EditableCell,
@@ -366,15 +379,7 @@ export default function CustomerTable() {
         cell: EditableCell,
         meta: { defaultType: 'text' },
       },
-      {
-        accessorFn: (row) =>
-          row.company_name ??
-          (row.customer_sub_type === 'business' ? row.contact_name : ''),
-        id: 'company_name',
-        header: 'Company',
-        cell: EditableCell,
-        meta: { defaultType: 'text', noTypeSelector: true },
-      },
+      ...pinnedCustomCols,
       {
         accessorKey: 'email',
         header: 'Email',
@@ -387,16 +392,15 @@ export default function CustomerTable() {
         cell: EditableCell,
         meta: { defaultType: 'phone' },
       },
-      {
-        accessorFn: (row) => row.billing_address?.address ?? '',
-        id: 'address',
-        header: 'Billing Address',
-        cell: EditableCell,
-        meta: { defaultType: 'text' },
-      },
-      ...customFieldColumns,
+      ...otherCustomCols,
     ],
-    [customFieldColumns, expandedRows, toggleExpanded, queryClient]
+    [
+      pinnedCustomCols,
+      otherCustomCols,
+      expandedRows,
+      toggleExpanded,
+      queryClient,
+    ]
   )
 
   /** Collect all enum values for a column from currently-loaded contacts */
@@ -446,6 +450,7 @@ export default function CustomerTable() {
         changes.push({
           contactId,
           contactName: contact.contact_name,
+          fieldId: columnId,
           field: fieldLabel,
           original,
           newValue,
@@ -812,11 +817,23 @@ export default function CustomerTable() {
                     ))}
                   </Table.Tr>,
                   isExpanded && (
-                    <Table.Tr key={`${row.id}-persons`}>
+                    <Table.Tr key={`${row.id}-detail`}>
                       <Table.Td
                         colSpan={columns.length}
                         style={{ padding: 0, background: '#f9fafb' }}
                       >
+                        <ContactDetailPanel
+                          contact={row.original}
+                          isEditMode={isEditMode}
+                          isDirty={isDirty}
+                          getDirtyValue={getDirtyValue}
+                          markDirty={markDirty}
+                          clearDirty={clearDirty}
+                          setValidationError={setValidationError}
+                          clearValidationError={clearValidationError}
+                          getColType={getColType}
+                          getEnumValues={getEnumValues}
+                        />
                         <ContactPersonsPanel
                           contactId={row.id}
                           contacts={contacts}

--- a/src/lib/csvImport.js
+++ b/src/lib/csvImport.js
@@ -52,8 +52,28 @@ export const IGNORE_BY_DEFAULT = new Set([
   'Account Name (Local)',
 ])
 
+/**
+ * Derived field rules auto-detected for the Lions Club CSV format.
+ * A derived rule combines multiple CSV columns into one Zoho field.
+ * Only applied when ALL part.csvHeader values are present in the file's headers.
+ *
+ * Rule shape: { target, parts: [{ csvHeader, prefix }], skipEmpty }
+ *   combined = part[0].value + (prefix + partN.value) for each non-empty part
+ */
+export const AUTO_DERIVED_RULES = [
+  {
+    target: 'last_name',
+    parts: [
+      { csvHeader: 'Contact: Last Name', prefix: '' },
+      { csvHeader: 'Contact: Suffix', prefix: ' ' },
+    ],
+    skipEmpty: true,
+  },
+]
+
 const MAPPING_STORAGE_KEY = 'csvImport.mapping'
 const MATCH_KEY_STORAGE_KEY = 'csvImport.matchKey'
+const DERIVED_RULES_STORAGE_KEY = 'csvImport.derivedRules'
 
 export function loadSavedMapping() {
   try {
@@ -92,14 +112,68 @@ export function saveMatchKey(csvHeader, zohoField) {
   }
 }
 
+export function loadSavedDerivedRules() {
+  try {
+    const raw = localStorage.getItem(DERIVED_RULES_STORAGE_KEY)
+    return raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+}
+
+export function saveDerivedRules(rules) {
+  try {
+    localStorage.setItem(DERIVED_RULES_STORAGE_KEY, JSON.stringify(rules))
+  } catch {
+    // ignore storage errors
+  }
+}
+
+/**
+ * Returns the subset of AUTO_DERIVED_RULES that are applicable to the given
+ * CSV headers (all required source columns are present in the file).
+ */
+export function initialDerivedRules(headers) {
+  const headerSet = new Set(headers)
+  return AUTO_DERIVED_RULES.filter((rule) =>
+    rule.parts.every((p) => headerSet.has(p.csvHeader))
+  )
+}
+
+/**
+ * Try to match a CSV header to a custom field's api_name by fuzzy label
+ * comparison. Strips "Contact: " prefix and normalizes whitespace/case.
+ */
+function fuzzyMatchCustomField(csvHeader, customFields) {
+  const normalized = csvHeader
+    .replace(/^Contact:\s*/i, '')
+    .toLowerCase()
+    .replace(/\s+/g, '')
+  const match = customFields.find((cf) => {
+    const label = (cf.label ?? cf.api_name).toLowerCase().replace(/\s+/g, '')
+    return label === normalized
+  })
+  return match?.api_name ?? null
+}
+
 /**
  * Build the initial column mapping for a set of CSV headers.
- * Prefers saved mapping, falls back to AUTO_MAP, then '__ignore__'.
+ * Prefers saved mapping, falls back to AUTO_MAP, then fuzzy custom-field
+ * label matching, then '__ignore__'.
+ *
+ * @param {string[]} headers
+ * @param {Array<{api_name, label}>} customFields — from the loaded contacts
  */
-export function initialMapping(headers) {
+export function initialMapping(headers, customFields = []) {
   const saved = loadSavedMapping() ?? {}
   return Object.fromEntries(
-    headers.map((h) => [h, saved[h] ?? AUTO_MAP[h] ?? '__ignore__'])
+    headers.map((h) => [
+      h,
+      saved[h] ??
+        AUTO_MAP[h] ??
+        fuzzyMatchCustomField(h, customFields) ??
+        '__ignore__',
+    ])
   )
 }
 
@@ -130,26 +204,31 @@ function normalizeWs(s) {
 }
 
 /**
- * Apply a column mapping to parsed CSV rows, producing dirty-map entries.
+ * Apply a column mapping (and optional derived rules) to parsed CSV rows,
+ * producing dirty-map entries.
  *
- * @param {Object[]} csvRows - rows from PapaParse (header: true)
- * @param {Object}   mapping - { [csvHeader]: zohoFieldId | '__ignore__' }
- * @param {string}   matchCsvHeader - CSV column used to identify the contact
- * @param {string}   matchZohoField - Zoho field to compare match value against
- * @param {Object[]} contacts - loaded Zoho contacts
- * @returns {{ dirtyMap: Object, matchedCount: number, unmatchedCount: number }}
- *   dirtyMap: { [contactId]: { [zohoFieldId]: newValue } }
+ * @param {Object[]} csvRows      - rows from PapaParse (header: true)
+ * @param {Object}   mapping      - { [csvHeader]: zohoFieldId | '__ignore__' }
+ * @param {string}   matchCsvHeader
+ * @param {string}   matchZohoField
+ * @param {Object[]} contacts     - loaded Zoho contacts
+ * @param {Object[]} derivedRules - optional derived-field combination rules
+ * @returns {{ dirtyMap, matchedCount, unmatchedCount }}
  */
 export function applyMapping(
   csvRows,
   mapping,
   matchCsvHeader,
   matchZohoField,
-  contacts
+  contacts,
+  derivedRules = []
 ) {
   const dirtyMap = {}
   let matchedCount = 0
   let unmatchedCount = 0
+
+  // Fields handled by derived rules — skip in the regular 1:1 loop
+  const derivedTargets = new Set(derivedRules.map((r) => r.target))
 
   for (const row of csvRows) {
     const matchValue = normalizeWs(row[matchCsvHeader])
@@ -168,8 +247,10 @@ export function applyMapping(
     const contactId = contact.contact_id
     const fields = {}
 
+    // Regular 1:1 mapping (skip fields covered by a derived rule)
     for (const [csvHeader, zohoField] of Object.entries(mapping)) {
       if (zohoField === '__ignore__') continue
+      if (derivedTargets.has(zohoField)) continue
       const csvValue = normalizeWs(row[csvHeader])
       const currentValue = normalizeWs(getContactFieldValue(contact, zohoField))
       if (csvValue !== currentValue) {
@@ -181,6 +262,29 @@ export function applyMapping(
           JSON.stringify(currentValue)
         )
         fields[zohoField] = csvValue
+      }
+    }
+
+    // Derived rules — combine multiple CSV columns into one Zoho field
+    for (const rule of derivedRules) {
+      let combined = ''
+      for (const part of rule.parts) {
+        const v = normalizeWs(row[part.csvHeader] ?? '')
+        if (!v && rule.skipEmpty) continue
+        combined = combined === '' ? v : combined + part.prefix + v
+      }
+      const currentValue = normalizeWs(
+        getContactFieldValue(contact, rule.target)
+      )
+      if (combined !== currentValue) {
+        debugLog(
+          `csv-derived contact=${contact.contact_name} field=${rule.target}`,
+          '\n  combined:',
+          JSON.stringify(combined),
+          '\n  zoho:   ',
+          JSON.stringify(currentValue)
+        )
+        fields[rule.target] = combined
       }
     }
 


### PR DESCRIPTION
## Summary

- **Contact detail panel**: Expanded rows now show a `ContactDetailPanel` above `ContactPersonsPanel`, with all fields grouped (Basic Info, Billing Address, Member Info) — fully editable in edit mode. Exposes `mobile` and all billing sub-fields (city/state/zip/country) that previously had no UI entry point.
- **Minimized table columns**: Table now shows first name, last name, member ID, email, phone, member type. `customer_sub_type`, `company_name`, and `address` moved to the detail panel.
- **CSV derived field rules**: Auto-detects the Lions CSV "Last Name + Suffix" combination rule; supports user-defined column-combination rules with localStorage persistence. Fuzzy-matches custom field labels for auto-mapping (e.g. "Contact Member ID" → `cf_member_id`).
- **Grouped commit modal**: Replaces flat table with per-contact cards; address sub-fields indented under "Billing Address" heading.
- **buildPayload fixes**: Now includes `mobile` in every PUT payload; falls back to `original.contact_name` when computed name is empty (fixes blank-name individual contacts).

## Test plan

- [ ] Expand a contact row → ContactDetailPanel shows grouped fields (Basic Info, Billing Address, Member Info)
- [ ] In edit mode, change `billing_city` in the panel → orange border appears, value shows in commit modal
- [ ] Import Lions CSV → "Contact: Last Name + Contact: Suffix → last_name" rule appears in derived rules section
- [ ] "Contact Member ID" column auto-maps to Member ID (`cf_member_id`) without manual selection
- [ ] Commit modal shows one card per contact; address changes grouped under "Billing Address"
- [ ] Table columns show: expander | First Name | Last Name | Member ID | Email | Phone | Member Type
- [ ] Contacts with blank first/last name can have other fields committed without error

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)