### PR TITLE
fix: reconcile dirtyMap against server values on contact load

### DIFF
--- a/src/components/CustomerTable.jsx
+++ b/src/components/CustomerTable.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react'
+import { useState, useCallback, useMemo, useEffect } from 'react'
 import {
   useReactTable,
   getCoreRowModel,
@@ -253,6 +253,43 @@ export default function CustomerTable() {
 
   const contacts = data?.contacts ?? []
   const pageContext = data?.page_context ?? {}
+
+  // Reconcile dirtyMap against freshly-loaded contacts: drop any entry where
+  // the stored dirty value already equals the current server value. This
+  // prevents stale localStorage entries (e.g. from a previous CSV import that
+  // set a field to '' when the server also has '') from showing as false-positive
+  // dirty cells on the next visit.
+  useEffect(() => {
+    if (!contacts.length) return
+    const normalize = (s) =>
+      String(s ?? '')
+        .trim()
+        .replace(/\s+/g, ' ')
+    setDirtyMap((prev) => {
+      let changed = false
+      const next = { ...prev }
+      for (const [contactId, fields] of Object.entries(next)) {
+        const contact = contacts.find((c) => c.contact_id === contactId)
+        if (!contact) continue
+        const remaining = { ...fields }
+        for (const [fieldId, dirtyValue] of Object.entries(remaining)) {
+          if (
+            normalize(dirtyValue) ===
+            normalize(getContactFieldValue(contact, fieldId))
+          ) {
+            delete remaining[fieldId]
+            changed = true
+          }
+        }
+        if (Object.keys(remaining).length === 0) {
+          delete next[contactId]
+        } else {
+          next[contactId] = remaining
+        }
+      }
+      return changed ? next : prev
+    })
+  }, [contacts]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Build columns dynamically, adding any custom fields from the first contact
   const customFieldColumns = useMemo(() => {


### PR DESCRIPTION
## Summary

- On each contacts data load/refresh, scan `dirtyMap` entries and drop any where `normalize(dirtyValue) === normalize(serverValue)`
- Prevents stale localStorage entries from previous CSV imports (e.g. blank address fields) from showing as false-positive dirty cells in the contact detail panel

## Root cause

`useEditState` restores `dirtyMap` from localStorage on mount but never reconciles against fresh server data. A CSV import that set address fields to `''` (because the CSV column was blank) would persist those entries indefinitely, making the fields appear dirty with blank values on every subsequent visit.

## Test plan

- [ ] Import a CSV with blank address columns → address fields appear dirty
- [ ] Refresh the page → address fields are no longer dirty (reconciliation cleaned them up)
- [ ] Make a real edit to a field → survives the reconciliation (dirty value differs from server)

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)